### PR TITLE
[clash] 1. add missing 'Edge' string in ws-headers;  2. keep proxies in base rule file

### DIFF
--- a/speedtestutil.cpp
+++ b/speedtestutil.cpp
@@ -816,7 +816,7 @@ void explodeClash(Node yamlnode, std::string custom_port, int local_port, std::v
     nodeInfo node;
     unsigned int index = nodes.size();
     std::string proxytype, ps, server, port, cipher, group, password; //common
-    std::string type = "none", id, aid = "0", net = "tcp", path, host, tls; //vmess
+    std::string type = "none", id, aid = "0", net = "tcp", path, host, edge, tls; //vmess
     std::string plugin, pluginopts, pluginopts_mode, pluginopts_host; //ss
     std::string protocol, protoparam, obfs, obfsparam; //ssr
     std::string user; //socks
@@ -844,9 +844,13 @@ void explodeClash(Node yamlnode, std::string custom_port, int local_port, std::v
             else
                 host = "";
 
+            if(yamlnode["Proxy"][i]["ws-headers"].IsDefined())
+                yamlnode["Proxy"][i]["ws-headers"]["Edge"] >> edge;
+            else
+                edge = "";
 
             node.linkType = SPEEDTEST_MESSAGE_FOUNDVMESS;
-            node.proxyStr = vmessConstruct(server, port, type, id, aid, net, cipher, path, host, tls, local_port);
+            node.proxyStr = vmessConstruct(server, port, type, id, aid, net, cipher, path, host, tls, local_port, edge);
         }
         else if(proxytype == "ss")
         {

--- a/speedtestutil.h
+++ b/speedtestutil.h
@@ -7,7 +7,7 @@
 #include "misc.h"
 #include "nodeinfo.h"
 
-std::string vmessConstruct(std::string add, std::string port, std::string type, std::string id, std::string aid, std::string net, std::string cipher, std::string path, std::string host, std::string tls, int local_port);
+std::string vmessConstruct(std::string add, std::string port, std::string type, std::string id, std::string aid, std::string net, std::string cipher, std::string path, std::string host, std::string tls, int local_port, std::string edge = "");
 std::string ssrConstruct(std::string group, std::string remarks, std::string remarks_base64, std::string server, std::string port, std::string protocol, std::string method, std::string obfs, std::string password, std::string obfsparam, std::string protoparam, int local_port, bool libev);
 std::string ssConstruct(std::string server, std::string port, std::string password, std::string method, std::string plugin, std::string pluginopts, std::string remarks, int local_port, bool libev);
 std::string socksConstruct(std::string remarks, std::string server, std::string port, std::string username, std::string password);

--- a/subexport.cpp
+++ b/subexport.cpp
@@ -400,6 +400,13 @@ std::string netchToClash(std::vector<nodeInfo> &nodes, std::string &base_conf, s
     try
     {
         yamlnode = YAML::Load(base_conf);
+        if(yamlnode["Proxy"].IsDefined())
+        {
+            for(unsigned int i = 0; i < yamlnode["Proxy"].size(); i++)
+            {
+                proxies.push_back(yamlnode["Proxy"][i]);
+            }
+        }
     }
     catch (std::exception &e)
     {

--- a/subexport.cpp
+++ b/subexport.cpp
@@ -19,7 +19,7 @@ extern bool add_emoji, remove_old_emoji;
 extern bool api_mode;
 extern string_array ss_ciphers, ssr_ciphers;
 
-std::string vmessConstruct(std::string add, std::string port, std::string type, std::string id, std::string aid, std::string net, std::string cipher, std::string path, std::string host, std::string tls, int local_port)
+std::string vmessConstruct(std::string add, std::string port, std::string type, std::string id, std::string aid, std::string net, std::string cipher, std::string path, std::string host, std::string tls, int local_port, std::string edge)
 {
     if(!port.size())
         port = "0";
@@ -50,6 +50,11 @@ std::string vmessConstruct(std::string add, std::string port, std::string type, 
     {
         writer.Key("Host");
         writer.String(host.data());
+        if(edge.size())
+        {
+          writer.Key("Edge");
+          writer.String(edge.data());
+        }
         writer.Key("Path");
         writer.String(path.data());
     }
@@ -386,7 +391,7 @@ std::string netchToClash(std::vector<nodeInfo> &nodes, std::string &base_conf, s
     std::string type, remark, hostname, port, username, password, method;
     std::string plugin, pluginopts;
     std::string protocol, protoparam, obfs, obfsparam;
-    std::string id, aid, transproto, faketype, host, path, quicsecure, quicsecret;
+    std::string id, aid, transproto, faketype, host, edge, path, quicsecure, quicsecret;
     std::vector<nodeInfo> nodelist;
     std::string group;
     bool tlssecure, replace_flag;
@@ -443,6 +448,7 @@ std::string netchToClash(std::vector<nodeInfo> &nodes, std::string &base_conf, s
             aid = GetMember(json, "AlterID");
             transproto = GetMember(json, "TransferProtocol");
             host = GetMember(json, "Host");
+            edge = GetMember(json, "Edge");
             path = GetMember(json, "Path");
             tlssecure = GetMember(json, "TLSSecure") == "true";
             singleproxy["type"] = "vmess";
@@ -455,6 +461,9 @@ std::string netchToClash(std::vector<nodeInfo> &nodes, std::string &base_conf, s
                 singleproxy["network"] = transproto;
                 singleproxy["ws-path"] = path;
                 singleproxy["ws-headers"]["Host"] = host;
+                singleproxy["ws-headers"]["Edge"] = edge;
+                singleproxy["headers"]["Host"] = host;
+                singleproxy["headers"]["Edge"] = edge;
             }
             else if(transproto == "kcp" || transproto == "h2" || transproto == "quic")
                 continue;


### PR DESCRIPTION
Draft commit only, not familiar with clash and other protocols, reference for you only.
- commit 1
  + add missing 'Edge' string in ws-headers
  + add missing 'headers' config in proxy

- commit 2
  + import the proxies in the base rule file.
but this commit will introduce the problem of duplicate proxies in the generated files. And also, the jsonlize to the proxies in the base rule files are not added, prepend to the proxy list only.
