### PR TITLE
fix(interfaces.cpp): readGroup() didnt work.

### DIFF
--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -488,8 +488,8 @@ void readGroup(YAML::Node node, string_array &dest, bool scope_limit = true)
         std::string url = "http://www.gstatic.com/generate_204", interval = "300", tolerance, timeout;
         object["name"] >>= name;
         object["type"] >>= type;
-        tempArray.emplace_back("name=" + name);
-        tempArray.emplace_back("type=" + type);
+        tempArray.emplace_back(name);
+        tempArray.emplace_back(type);
         object["url"] >>= url;
         object["interval"] >>= interval;
         object["tolerance"] >>= tolerance;
@@ -509,13 +509,13 @@ void readGroup(YAML::Node node, string_array &dest, bool scope_limit = true)
         default:
             if(tempArray.size() < 3)
                 continue;
-            tempArray.emplace_back("url=" + url);
-            tempArray.emplace_back("interval=" + interval + ",timeout=" + timeout + ",tolerance=" + tolerance);
+            tempArray.emplace_back(url);
+            tempArray.emplace_back(interval + "," + timeout + "," + tolerance);
         }
 
         strLine = std::accumulate(std::next(tempArray.begin()), tempArray.end(), tempArray[0], [](std::string a, std::string b) -> std::string
         {
-            return std::move(a) + "," + std::move(b);
+            return std::move(a) + "`" + std::move(b);
         });
         dest.emplace_back(std::move(strLine));
     }

--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -485,7 +485,7 @@ void readGroup(YAML::Node node, string_array &dest, bool scope_limit = true)
             dest.emplace_back("!!import:" + name);
             continue;
         }
-        std::string url = "http://www.gstatic.com/generate_204", interval = "300", tolerance, timeout;
+        std::string url = "http://www.gstatic.com/generate_204", interval = "300", tolerance, timeout, strategy;
         object["name"] >>= name;
         object["type"] >>= type;
         tempArray.emplace_back(name);
@@ -494,6 +494,7 @@ void readGroup(YAML::Node node, string_array &dest, bool scope_limit = true)
         object["interval"] >>= interval;
         object["tolerance"] >>= tolerance;
         object["timeout"] >>= timeout;
+        object["strategy"] >>= strategy;
         for(j = 0; j < object["rule"].size(); j++)
             tempArray.emplace_back(safe_as<std::string>(object["rule"][j]));
         switch(hash_(type))
@@ -510,7 +511,7 @@ void readGroup(YAML::Node node, string_array &dest, bool scope_limit = true)
             if(tempArray.size() < 3)
                 continue;
             tempArray.emplace_back(url);
-            tempArray.emplace_back(interval + "," + timeout + "," + tolerance);
+            tempArray.emplace_back(interval + "," + timeout + "," + tolerance+ "," + strategy);
         }
 
         strLine = std::accumulate(std::next(tempArray.begin()), tempArray.end(), tempArray[0], [](std::string a, std::string b) -> std::string


### PR DESCRIPTION
Yaml外部配置读取的readGroup函数无法正常运行。tempArray添加元素时，值中混合了元素名导致生成的strLine为：``` name=GroupName,type=select,.* ```，而读取ini格式的custom_proxy_groups生成的strLine为：``` GroupName`select`.* ```

修改后自行编译测试，结果符合预期。