### PR TITLE
fix(subparser): SIP008 decoder

### DIFF
--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -495,7 +495,7 @@ void explodeSSConf(std::string content, std::vector<Proxy> &nodes)
     json.Parse(content.data());
     if(json.HasParseError())
         return;
-    const char *section = json.HasMember("version") && json.HasMember("remarks") && json.HasMember("servers") ? "servers" : "configs";
+    const char *section = json.HasMember("version") && json.HasMember("servers") ? "servers" : "configs";
     if(!json.HasMember(section))
         return;
     GetMember(json, "remarks", group);


### PR DESCRIPTION
fix #366

The SIP008 subscription can not be converted correctly when the member "remarks" does not exist.

The code here may cause the SIP008 subscription can not be converted correctly.

https://github.com/tindy2013/subconverter/blob/867602fbeabd65aeb92caaabcabac4fa4c5f3985/src/parser/subparser.cpp#L498-L500

https://shadowsocks.org/en/wiki/SIP008-Online-Configuration-Delivery.html