### PR TITLE
Use multi-stage builds

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.13 AS builder
 LABEL maintainer "tindy.it@gmail.com"
 ARG THREADS="4"
 ARG SHA=""
@@ -37,14 +37,18 @@ RUN apk add --no-cache --virtual .build-tools git g++ build-base linux-headers c
     cd subconverter && \
     [ -n "$SHA" ] && sed -i 's/\(v[0-9]\.[0-9]\.[0-9]\)/\1-'"$SHA"'/' src/version.h;\
     cmake -DCMAKE_BUILD_TYPE=Release . && \
-    make -j $THREADS && \
-    mv subconverter /usr/bin && \
-    mv base ../ && \
-    cd .. && \
-    rm -rf subconverter quickjspp libcron toml11 /usr/lib/lib*.a /usr/include/* /usr/local/include/lib*.a /usr/local/include/* && \
-    apk add --no-cache --virtual subconverter-deps pcre2 libcurl yaml-cpp libevent && \
-    apk del .build-tools .build-deps
+    make -j $THREADS
+
+FROM alpine:3.13
+LABEL maintainer "tindy.it@gmail.com"
+
+RUN apk add --no-cache --virtual subconverter-deps pcre2 libcurl yaml-cpp libevent
+
+COPY --from=builder /subconverter/subconverter /usr/bin/
+COPY --from=builder /subconverter/base /base/
 
 # set entry
 WORKDIR /base
 CMD subconverter
+
+EXPOSE 25500/tcp


### PR DESCRIPTION
使用 `container-diff diff tindy2013/subconverter:0.7.1 alpine:3.13 --type=file` 可以看到，编译 [ToruNiina/toml11](https://github.com/ToruNiina/toml11) 产生的多余文件仍有部分没被清理，使用[多阶段构建](https://docs.docker.com/develop/develop-images/multistage-build/)就不用[手动进行清理操作](https://github.com/tindy2013/subconverter/blob/v0.7.1/scripts/Dockerfile#L44)了。
```
...
\usr\local\include                                                                                         0
\usr\local\lib64                                                                                           5.9K
\usr\local\lib64\cmake                                                                                     5.9K
\usr\local\lib64\cmake\toml11                                                                              5.9K
\usr\local\lib64\cmake\toml11\toml11Config.cmake                                                           951B
\usr\local\lib64\cmake\toml11\toml11ConfigVersion.cmake                                                    1.7K
\usr\local\lib64\cmake\toml11\toml11Targets.cmake                                                          3.3K
...
```