### PR TITLE
add Stash for iOS

### DIFF
--- a/base/pref.example.ini
+++ b/base/pref.example.ini
@@ -237,6 +237,7 @@ clash.log_level=info
 /mellow=/sub?target=mellow
 /surfboard=/sub?target=surfboard
 /loon=/sub?target=loon
+/stash=/sub?target=stash
 /ss=/sub?target=ss
 /ssd=/sub?target=ssd
 /sssub=/sub?target=sssub

--- a/base/pref.example.toml
+++ b/base/pref.example.toml
@@ -267,6 +267,10 @@ uri = "/loon"
 target = "/sub?target=loon"
 
 [[aliases]]
+uri = "/stash"
+target = "/sub?target=stash"
+
+[[aliases]]
 uri = "/ss"
 target = "/sub?target=ss"
 

--- a/base/pref.example.yml
+++ b/base/pref.example.yml
@@ -116,6 +116,7 @@ aliases:
   - {uri: /mellow, target: "/sub?target=mellow"}
   - {uri: /surfboard, target: "/sub?target=surfboard"}
   - {uri: /loon, target: "/sub?target=loon"}
+  - {uri: /stash, target: "/sub?target=stash"}
   - {uri: /ss, target: "/sub?target=ss"}
   - {uri: /ssd, target: "/sub?target=ssd"}
   - {uri: /sssub, target: "/sub?target=sssub"}

--- a/src/generator/config/ruleconvert.h
+++ b/src/generator/config/ruleconvert.h
@@ -31,6 +31,7 @@ struct RulesetContent
 std::string convertRuleset(const std::string &content, int type);
 void rulesetToClash(YAML::Node &base_rule, std::vector<RulesetContent> &ruleset_content_array, bool overwrite_original_rules, bool new_field_name);
 std::string rulesetToClashStr(YAML::Node &base_rule, std::vector<RulesetContent> &ruleset_content_array, bool overwrite_original_rules, bool new_field_name);
+std::string rulesetToStashStr(YAML::Node &base_rule, std::vector<RulesetContent> &ruleset_content_array, bool overwrite_original_rules);
 void rulesetToSurge(INIReader &base_rule, std::vector<RulesetContent> &ruleset_content_array, int surge_ver, bool overwrite_original_rules, std::string remote_path_prefix);
 
 #endif // RULECONVERT_H_INCLUDED

--- a/src/generator/config/subexport.h
+++ b/src/generator/config/subexport.h
@@ -61,6 +61,8 @@ void rulesetToSurge(INIReader &base_rule, std::vector<RulesetContent> &ruleset_c
 
 std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, bool clashR, extra_settings &ext);
 void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupConfigs &extra_proxy_group, bool clashR, extra_settings &ext);
+std::string proxyToStash(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext);
+void proxyToStash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext);
 std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, int surge_ver, extra_settings &ext);
 std::string proxyToMellow(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext);
 void proxyToMellow(std::vector<Proxy> &nodes, INIReader &ini, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext);

--- a/src/generator/template/templates.h
+++ b/src/generator/template/templates.h
@@ -17,5 +17,6 @@ struct template_args
 
 int render_template(const std::string &content, const template_args &vars, std::string &output, const std::string &include_scope = "templates");
 int renderClashScript(YAML::Node &base_rule, std::vector<RulesetContent> &ruleset_content_array, std::string remote_path_prefix, bool script, bool overwrite_original_rules, bool clash_classic_ruleset);
+int renderStashScript(YAML::Node &base_rule, std::vector<RulesetContent> &ruleset_content_array, std::string remote_path_prefix, bool overwrite_original_rules);
 
 #endif // TEMPLATES_H_INCLUDED

--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -49,7 +49,7 @@ std::string parseProxy(const std::string &source)
     return proxy;
 }
 
-extern string_array ClashRuleTypes, SurgeRuleTypes, QuanXRuleTypes;
+extern string_array ClashRuleTypes, SurgeRuleTypes, QuanXRuleTypes, StashRuleTypes;
 
 struct UAProfile
 {
@@ -70,6 +70,7 @@ const std::vector<UAProfile> UAMatchList = {
     {"ClashX Pro","","","clash",true},
     {"ClashX","\\/([0-9.]+)","0.13","clash",true},
     {"Clash","","","clash",true},
+    {"Stash","","","stash",true},
     {"Kitsunebi","","","v2ray"},
     {"Loon","","","loon"},
     {"Pharos","","","mixed"},
@@ -327,7 +328,7 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
     case "ss"_hash: case "ssd"_hash: case "ssr"_hash: case "sssub"_hash: case "v2ray"_hash: case "trojan"_hash: case "mixed"_hash:
         lSimpleSubscription = true;
         break;
-    case "clash"_hash: case "clashr"_hash: case "surge"_hash: case "quan"_hash: case "quanx"_hash: case "loon"_hash: case "surfboard"_hash: case "mellow"_hash:
+    case "clash"_hash: case "clashr"_hash: case "surge"_hash: case "quan"_hash: case "quanx"_hash: case "loon"_hash: case "surfboard"_hash: case "mellow"_hash: case "stash"_hash:
         break;
     default:
         *status_code = 400;
@@ -872,6 +873,30 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
 
         if(argUpload)
             uploadGist("loon", argUploadPath, output_content, false);
+        break;
+    case "stash"_hash:
+        writeLog(0, "Generate target: Stash", LOG_LEVEL_INFO);
+        ext.clash_new_field_name = true;
+        tpl_args.local_vars["clash.new_field_name"] = "true";
+        response.headers["profile-update-interval"] = std::to_string(interval / 3600);
+        if(ext.nodelist)
+        {
+            YAML::Node yamlnode;
+            proxyToStash(nodes, yamlnode, dummy_group, ext);
+            output_content = YAML::Dump(yamlnode);
+        }
+        else
+        {
+            if(render_template(fetchFile(lClashBase, proxy, global.cacheConfig), tpl_args, base_content, global.templatePath) != 0)
+            {
+                *status_code = 400;
+                return base_content;
+            }
+            output_content = proxyToStash(nodes, base_content, lRulesetContent, lCustomProxyGroups, ext);
+        }
+
+        if(argUpload)
+            uploadGist(argTarget, argUploadPath, output_content, false);
         break;
     case "ssd"_hash:
         writeLog(0, "Generate target: SSD", LOG_LEVEL_INFO);


### PR DESCRIPTION
订阅转换增加 Stash for iOS 支持；

Stash 是一款 iOS 平台基于规则的多协议代理客户端，完全兼容 clash 配置，支持 Rule Set、USER-AGENT，URL-REGEX 等规则，和按需连接、SSID Policy Group 等特性。

App Store 链接：https://apps.apple.com/app/stash/id1596063349

技术细节：
由于 Stash 支持 USER-AGENT，URL-REGEX 等规则，因此无法直接复用 Clash 的代码，我们已根据作者的逻辑写了 Stash 转换，并已经经过测试。同时出于移动端性能的考虑，我们默认启用 Rule Set 和不使用 Classical ，因此 /getruleset 接口没做修改。
