### PR TITLE
Support HEAD request

### DIFF
--- a/scripts/Dockerfile.dev
+++ b/scripts/Dockerfile.dev
@@ -1,0 +1,50 @@
+FROM alpine:3.13
+LABEL maintainer "tindy.it@gmail.com"
+ARG THREADS="4"
+ARG SHA=""
+
+# build minimized
+WORKDIR /
+RUN apk add --no-cache --virtual .build-tools git g++ build-base linux-headers cmake && \
+    apk add --no-cache --virtual .build-deps curl-dev rapidjson-dev libevent-dev pcre2-dev yaml-cpp-dev && \
+    git clone https://github.com/ftk/quickjspp --depth=1 && \
+    cd quickjspp && \
+    git submodule update --init && \
+    cmake -DCMAKE_BUILD_TYPE=Release . && \
+    make quickjs -j $THREADS && \
+    install -m644 quickjs/libquickjs.a /usr/lib && \
+    install -d /usr/include/quickjs/ && \
+    install -m644 quickjs/quickjs.h quickjs/quickjs-libc.h /usr/include/quickjs/ && \
+    install -m644 quickjspp.hpp /usr/include && \
+    cd .. && \
+    git clone https://github.com/PerMalmberg/libcron --depth=1 && \
+    cd libcron && \
+    git submodule update --init && \
+    cmake -DCMAKE_BUILD_TYPE=Release . && \
+    make libcron -j $THREADS && \
+    install -m644 libcron/out/Release/liblibcron.a /usr/lib/ && \
+    install -d /usr/include/libcron/ && \
+    install -m644 libcron/include/libcron/* /usr/include/libcron/ && \
+    install -d /usr/include/date/ && \
+    install -m644 libcron/externals/date/include/date/* /usr/include/date/ && \
+    cd .. && \
+    git clone https://github.com/ToruNiina/toml11 --depth=1 && \
+    cd toml11 && \
+    cmake . && \
+    make install -j $THREADS 
+
+ADD . /src
+
+RUN cd /src && \
+    [ -n "$SHA" ] && sed -i 's/\(v[0-9]\.[0-9]\.[0-9]\)/\1-'"$SHA"'/' src/version.h;\
+    cmake -DCMAKE_BUILD_TYPE=Debug . && \
+    make -j $THREADS && \
+    mv subconverter /usr/bin && \
+    mv base ../ && \
+    cd .. && \
+    rm -rf subconverter quickjspp libcron toml11 /usr/lib/lib*.a /usr/include/* /usr/local/include/lib*.a /usr/local/include/* && \
+    apk add --no-cache --virtual subconverter-deps pcre2 libcurl yaml-cpp libevent 
+
+# set entry
+WORKDIR /base
+CMD subconverter

--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -676,6 +676,9 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
     if(subInfo.size() && argAppendUserinfo.get(global.appendUserinfo))
         response.headers.emplace("Subscription-UserInfo", subInfo);
 
+    if (request.method == "HEAD")
+        return "";
+
     //do pre-process now
     preprocessNodes(nodes, ext);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,6 +260,8 @@ int main(int argc, char *argv[])
         return "done";
     });
 
+    webServer.append_response("HEAD", "/sub", "text/plain;charset=utf-8", subconverter);
+
     webServer.append_response("GET", "/sub", "text/plain;charset=utf-8", subconverter);
 
     webServer.append_response("GET", "/sub2clashr", "text/plain;charset=utf-8", simpleToClashR);

--- a/src/server/webserver_libevent.cpp
+++ b/src/server/webserver_libevent.cpp
@@ -217,6 +217,7 @@ void WebServer::on_request(evhttp_request *req, void *args)
 
     switch (req->type)
     {
+        case EVHTTP_REQ_HEAD: request.method = "HEAD"; break;
         case EVHTTP_REQ_GET: request.method = "GET"; break;
         case EVHTTP_REQ_POST: request.method = "POST"; break;
         case EVHTTP_REQ_OPTIONS: request.method = "OPTIONS"; break;
@@ -304,7 +305,7 @@ int WebServer::start_web_server(void *argv)
 
     auto call_on_request = [&](evhttp_request *req, void *args) { on_request(req, args); };
 
-    evhttp_set_allowed_methods(server.get(), EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_OPTIONS | EVHTTP_REQ_PUT | EVHTTP_REQ_PATCH | EVHTTP_REQ_DELETE);
+    evhttp_set_allowed_methods(server.get(), EVHTTP_REQ_HEAD | EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_OPTIONS | EVHTTP_REQ_PUT | EVHTTP_REQ_PATCH | EVHTTP_REQ_DELETE);
     evhttp_set_gencb(server.get(), wrap(call_on_request), nullptr);
     evhttp_set_timeout(server.get(), 30);
     if (event_dispatch() == -1)
@@ -388,7 +389,7 @@ int WebServer::start_web_server_multi(void *argv)
         if (evhttp_accept_socket(httpd, nfd) != 0)
             return -1;
 
-        evhttp_set_allowed_methods(httpd, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_OPTIONS | EVHTTP_REQ_PUT | EVHTTP_REQ_PATCH | EVHTTP_REQ_DELETE);
+        evhttp_set_allowed_methods(httpd, EVHTTP_REQ_HEAD | EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_OPTIONS | EVHTTP_REQ_PUT | EVHTTP_REQ_PATCH | EVHTTP_REQ_DELETE);
         evhttp_set_gencb(httpd, wrap(call_on_request), nullptr);
         evhttp_set_timeout(httpd, 30);
         if (pthread_create(&ths[i], nullptr, httpserver_dispatch, base[i]) != 0)


### PR DESCRIPTION
`/sub` 支持 HEAD 请求

可以用来查询订阅信息，无需返回完整配置文件内容。

```console
-> % curl -I http://127.0.0.1:25500/sub\?target\=clash\&url\=SUBSCRIPTION_URL&config\=https%3A%2F%2Fraw.githubusercontent.com%2FWatfaq%2Fchoc-configs%2Fmain%2Fconfigs%2Fbasic.ini\&emoji\=false\&list\=false\&tfo\=false\&scv\=false\&fdn\=false\&sort\=false\&new_name\=true
HTTP/1.1 200 OK
Subscription-UserInfo: upload=1726462333; download=28963911471; total=1073741824000; expire=1670245600
Content-Type: text/plain;charset=utf-8
Access-Control-Allow-Origin: *
Connection: close
Date: Thu, 06 Jan 2022 00:55:45 GMT
```