### PR TITLE
Fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,6 @@ body:
       - label: 我已经检索过现有[issue](https://github.com/tindy2013/subconverter/issues)，确认与现有issue的内容并不重复
         required: true
       - label: 我已经尝试自行解决，确认自己没有能力解决
-        required: true
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
If the label does not contain english characters and is required, it will cause the issue to fail to submit.
This should be a github bug