### PR TITLE
Update request header for webget.

### DIFF
--- a/src/handler/webget.cpp
+++ b/src/handler/webget.cpp
@@ -190,7 +190,7 @@ static int curlGet(const FetchArgument &argument, FetchResult &result)
     curl_progress_data limit;
     limit.size_limit = global.maxAllowedDownloadSize;
     curl_set_common_options(curl_handle, new_url.data(), &limit);
-    list = curl_slist_append(list, "Content-Type: application/json;charset='utf-8'");
+    list = curl_slist_append(list, "Content-Type: application/json;charset=utf-8");
     if(argument.request_headers)
     {
         for(auto &x : *argument.request_headers)


### PR DESCRIPTION
从一个ssr订阅转clash时发现个问题，请求此订阅链接无节点返回，调试时发现请求这个订阅链接时响应为403；
研究发现请求header里设置的Content-Type的影响；
稍稍修改了一下，若对其他请求有破坏，可忽略此PR