### PR TITLE
Fix bug on Surge when using WebSocket.

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -679,7 +679,10 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             case "tcp"_hash:
                 break;
             case "ws"_hash:
-                proxy += ", ws=true, ws-path=" + path + ", sni=" + host + ", ws-headers=Host:" + host;
+                if(host.empty())
+                    proxy += ", ws=true, ws-path=" + path + ", sni=" + hostname;
+                else
+                    proxy += ", ws=true, ws-path=" + path + ", sni=" + host + ", ws-headers=Host:" + host;
                 if(!edge.empty())
                     proxy += "|Edge:" + edge;
                 break;

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -682,7 +682,7 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
                 if(host.empty())
                     proxy += ", ws=true, ws-path=" + path + ", sni=" + hostname;
                 else
-                    proxy += ", ws=true, ws-path=" + path + ", sni=" + host + ", ws-headers=Host:" + host;
+                    proxy += ", ws=true, ws-path=" + path + ", sni=" + hostname + ", ws-headers=Host:" + host;
                 if(!edge.empty())
                     proxy += "|Edge:" + edge;
                 break;


### PR DESCRIPTION
**Fix Surge error reported when node's hostname is IP, using vmess-websocket, with null sni parameter.**

According to Surge's official documentation, the sni value should be hostname, not the disguised host of ws-headers.

> sni （默认值：hostname）
> 你可以在 TLS 握手时自定义 Server Name Indication（SNI）。通过添加 sni=off 可以关闭 SNI。 默认情况下，Surge 像大多数浏览器一样，会发送域名作为 SNI。