### PR TITLE
Remove VMess aead option in Quantumult X

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -1307,6 +1307,8 @@ void proxyToQuanX(std::vector<Proxy> &nodes, INIReader &ini, std::vector<Ruleset
             if(method == "auto")
                 method = "chacha20-ietf-poly1305";
             proxyStr = "vmess = " + hostname + ":" + port + ", method=" + method + ", password=" + id;
+            if (x.AlterId != 0)
+                proxyStr += ", aead=false";
             if(tlssecure && !tls13.is_undef())
                 proxyStr += ", tls13=" + std::string(tls13 ? "true" : "false");
             if(transproto == "ws")

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -1306,7 +1306,7 @@ void proxyToQuanX(std::vector<Proxy> &nodes, INIReader &ini, std::vector<Ruleset
         case ProxyType::VMess:
             if(method == "auto")
                 method = "chacha20-ietf-poly1305";
-            proxyStr = "vmess = " + hostname + ":" + port + ", method=" + method + ", password=" + id + ", aead=" + (x.AlterId == 0 ? "true" : "false");
+            proxyStr = "vmess = " + hostname + ":" + port + ", method=" + method + ", password=" + id;
             if(tlssecure && !tls13.is_undef())
                 proxyStr += ", tls13=" + std::string(tls13 ? "true" : "false");
             if(transproto == "ws")


### PR DESCRIPTION
如同 [issue 473](https://github.com/tindy2013/subconverter/issues/473)所探讨，在进行订阅链接转换时，会自动带上 aead=true 这个选项，QuanX 却没有识别到，但是服务端强制开启 aead，会导致节点连接失败。因为 QuanX 在1.0.27之后会默认自动开启 aead，复现过程与该 issue 完全相同。因此去除了 aead 选项。

使用subconverter v0.7.1-217891f backend时.配置无 aead=true.
quanX会显示aead已启用,且节点正常使用
使用subconverter v0.7.2-ce8d2bd backend时, 配置有aead=true.
quanX不会显示aead已启用,如服务端强制aead时, 节点将无法使用