### PR TITLE
更改vmess情况下tcp中http伪装无法转换为Clash的问题

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -297,7 +297,7 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
             case "tcp"_hash:
                 if(x.FakeType == "http")
                 {
-                    singleproxy["network"] = x.TransferProtocol;
+                    singleproxy["network"] = "http";
                     singleproxy["http-opts"]["method"] = "GET";
                     singleproxy["http-opts"]["path"].push_back(x.Path);
                     if(!x.Host.empty())

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -295,6 +295,16 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
             switch(hash_(x.TransferProtocol))
             {
             case "tcp"_hash:
+                if(x.FakeType == "http")
+                {
+                    singleproxy["network"] = x.TransferProtocol;
+                    singleproxy["http-opts"]["method"] = "GET";
+                    singleproxy["http-opts"]["path"].push_back(x.Path);
+                    if(!x.Host.empty())
+                        singleproxy["http-opts"]["headers"]["Host"].push_back(x.Host);
+                    if(!x.Edge.empty())
+                        singleproxy["http-opts"]["headers"]["Edge"].push_back(x.Edge);
+                }
                 break;
             case "ws"_hash:
                 singleproxy["network"] = x.TransferProtocol;

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -325,15 +325,6 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
                         singleproxy["ws-headers"]["Edge"] = x.Edge;
                 }
                 break;
-            case "http"_hash:
-                singleproxy["network"] = x.TransferProtocol;
-                singleproxy["http-opts"]["method"] = "GET";
-                singleproxy["http-opts"]["path"].push_back(x.Path);
-                if(!x.Host.empty())
-                    singleproxy["http-opts"]["headers"]["Host"].push_back(x.Host);
-                if(!x.Edge.empty())
-                    singleproxy["http-opts"]["headers"]["Edge"].push_back(x.Edge);
-                break;
             case "h2"_hash:
                 singleproxy["network"] = x.TransferProtocol;
                 singleproxy["h2-opts"]["path"] = x.Path;


### PR DESCRIPTION
#536 
本功能应该已经实现，但是判断的分支为net类型，然而不存在net类型为http的情况，将http伪装分支并入tcp内。