### PR TITLE
surge 4+ loading config error when obfs host is empty

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -754,7 +754,9 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
         case ProxyType::Snell:
             proxy = "snell, " + hostname + ", " + port + ", psk=" + password;
             if(!obfs.empty())
-                proxy += ", obfs=" + obfs + ", obfs-host=" + host;
+                proxy += ", obfs=" + obfs;
+                if(!host.empty())
+                    proxy += ", obfs-host=" + host
             break;
         default:
             continue;

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -756,7 +756,7 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             if(!obfs.empty())
                 proxy += ", obfs=" + obfs;
                 if(!host.empty())
-                    proxy += ", obfs-host=" + host
+                    proxy += ", obfs-host=" + host;
             break;
         default:
             continue;


### PR DESCRIPTION
surge 4+ loading config error when obfs host is empty:

![image](https://github.com/tindy2013/subconverter/assets/2975752/d797b188-60a5-4a29-bb46-dbc888a6a4cb)

So I changed it only adds it when host has not an empty string.