### PR TITLE
UDP is not supported yet in clash when using snell.

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -756,9 +756,11 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
         case ProxyType::Snell:
             proxy = "snell, " + hostname + ", " + port + ", psk=" + password;
             if(!obfs.empty())
+            {
                 proxy += ", obfs=" + obfs;
                 if(!host.empty())
                     proxy += ", obfs-host=" + host;
+            }
             break;
         default:
             continue;

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -754,7 +754,9 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
         case ProxyType::Snell:
             proxy = "snell, " + hostname + ", " + port + ", psk=" + password;
             if(!obfs.empty())
-                proxy += ", obfs=" + obfs + ", obfs-host=" + host;
+                proxy += ", obfs=" + obfs;
+                if(!host.empty())
+                    proxy += ", obfs-host=" + host
             break;
         default:
             continue;

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -443,7 +443,9 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
             continue;
         }
 
-        if(udp)
+        // UDP is not supported yet in clash using snell
+        // sees in https://dreamacro.github.io/clash/configuration/outbound.html#snell
+        if(udp && x.Type != ProxyType::Snell)
             singleproxy["udp"] = true;
         if(block)
             singleproxy.SetStyle(YAML::EmitterStyle::Block);

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -756,7 +756,7 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             if(!obfs.empty())
                 proxy += ", obfs=" + obfs;
                 if(!host.empty())
-                    proxy += ", obfs-host=" + host
+                    proxy += ", obfs-host=" + host;
             break;
         default:
             continue;


### PR DESCRIPTION
UDP is not supported yet in clash when using snell.
I found that using clash agent, It will casue a warn an fail to load the yaml.

![image](https://github.com/tindy2013/subconverter/assets/2975752/82f6388f-b342-4287-84ac-b20b6d3cfca4)

so I fixed it by checking the ProxyType is not snell.

See also:

![image](https://github.com/tindy2013/subconverter/assets/2975752/1fd426b0-147c-488d-9db0-47c152a9a288)

Hope you have a nice day.
