### PR TITLE
Fix client parse errors with '=' in remark strings

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -157,6 +157,11 @@ bool applyMatcher(const std::string &rule, std::string &real_rule, const Proxy &
 
 void processRemark(std::string &oldremark, std::string &newremark, string_array &remarks_list, bool proc_comma = true)
 {
+    // Replace every '=' with '-' in the remark string to avoid parse errors from the clients.
+    //     Surge is tested to yield an error when handling '=' in the remark string, 
+    //     not sure if other clients have the same problem.
+    std::replace(oldremark.begin(), oldremark.end(), '=', '-');
+
     if(proc_comma)
     {
         if(oldremark.find(',') != std::string::npos)


### PR DESCRIPTION
Replace every '=' with '-' in the remark string to avoid parse errors from the clients.
当节点名称中含有'='时，输出的conf文件可能无法被代理软件（如surge）正确解析，因此需要替换节点名称中的'='为'-'.