### PR TITLE
Fix bug on Surge when using WebSocket.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           platforms: linux/amd64
           context: scripts/
-          tags: tindy2013/subconverter:latest
+          tags: ruyenet/subconverter:latest
           build-args: |
             SHA=${{ steps.vars.outputs.sha_short }}
           outputs: type=image,push=true
@@ -60,7 +60,7 @@ jobs:
         with:
           platforms: linux/amd64
           context: scripts/
-          tags: tindy2013/subconverter:${{steps.version.outputs.result}}
+          tags: ruyenet/subconverter:${{steps.version.outputs.result}}
           outputs: type=image,push=true
 
       - name: Save digest
@@ -106,7 +106,7 @@ jobs:
         with:
           platforms: linux/386
           context: scripts/
-          tags: tindy2013/subconverter:latest
+          tags: ruyenet/subconverter:latest
           build-args: |
             SHA=${{ steps.vars.outputs.sha_short }}
           outputs: type=image,push=true
@@ -127,7 +127,7 @@ jobs:
         with:
           platforms: linux/386
           context: scripts/
-          tags: tindy2013/subconverter:${{steps.version.outputs.result}}
+          tags: ruyenet/subconverter:${{steps.version.outputs.result}}
           outputs: type=image,push=true
 
       - name: Save digest
@@ -173,7 +173,7 @@ jobs:
         with:
           platforms: linux/arm/v7
           context: scripts/
-          tags: tindy2013/subconverter:latest
+          tags: ruyenet/subconverter:latest
           build-args: |
             SHA=${{ steps.vars.outputs.sha_short }}
             THREADS=4
@@ -195,7 +195,7 @@ jobs:
         with:
           platforms: linux/arm/v7
           context: scripts/
-          tags: tindy2013/subconverter:${{steps.version.outputs.result}}
+          tags: ruyenet/subconverter:${{steps.version.outputs.result}}
           build-args: |
             THREADS=4
           outputs: type=image,push=true
@@ -243,7 +243,7 @@ jobs:
         with:
           platforms: linux/arm64
           context: scripts/
-          tags: tindy2013/subconverter:latest
+          tags: ruyenet/subconverter:latest
           build-args: |
             SHA=${{ steps.vars.outputs.sha_short }}
             THREADS=4
@@ -265,7 +265,7 @@ jobs:
         with:
           platforms: linux/arm64
           context: scripts/
-          tags: tindy2013/subconverter:${{steps.version.outputs.result}}
+          tags: ruyenet/subconverter:${{steps.version.outputs.result}}
           build-args: |
             THREADS=4
           outputs: type=image,push=true

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -35,7 +35,7 @@ RUN set -xe && \
     cmake -DCMAKE_CXX_STANDARD=11 . && \
     make install -j $THREADS && \
     cd .. && \
-    git clone https://github.com/tindy2013/subconverter --depth=1 && \
+    git clone https://github.com/ruyenet/subconverter --depth=1 && \
     cd subconverter && \
     [ -n "$SHA" ] && sed -i 's/\(v[0-9]\.[0-9]\.[0-9]\)/\1-'"$SHA"'/' src/version.h;\
     python3 -m ensurepip && \

--- a/scripts/merge_manifest.py
+++ b/scripts/merge_manifest.py
@@ -1,7 +1,7 @@
 import glob
 import os, sys
 
-MAIN_IMAGE_NAME="tindy2013/subconverter"
+MAIN_IMAGE_NAME="ruyenet/subconverter"
 TARGET_TAG="latest" if len(sys.argv) < 2 else sys.argv[1]
 
 args=["docker manifest create {}:{}".format(MAIN_IMAGE_NAME, TARGET_TAG)]

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -722,7 +722,10 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             case "tcp"_hash:
                 break;
             case "ws"_hash:
-                proxy += ", ws=true, ws-path=" + path + ", sni=" + hostname;
+                if(host.empty())
+                    proxy += ", ws=true, ws-path=" + path + ", sni=" + hostname;
+                else
+                    proxy += ", ws=true, ws-path=" + path + ", sni=" + host;
                 if(!host.empty())
                     headers.push_back("Host:" + host);
                 if(!edge.empty())


### PR DESCRIPTION
When the host name of the node using vmess-websocket is IP and the host in the headers is not empty, sni should be host instead of IP.