### PR TITLE
Fix bug on Surge when using WebSocket. 

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -722,7 +722,10 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             case "tcp"_hash:
                 break;
             case "ws"_hash:
-                proxy += ", ws=true, ws-path=" + path + ", sni=" + hostname;
+                if(host.empty())
+                    proxy += ", ws=true, ws-path=" + path + ", sni=" + hostname;
+                else
+                    proxy += ", ws=true, ws-path=" + path + ", sni=" + host;
                 if(!host.empty())
                     headers.push_back("Host:" + host);
                 if(!edge.empty())


### PR DESCRIPTION
When the host name of the node using vmess-websocket is IP and the host in the headers is not empty, sni should be host instead of IP.