### PR TITLE
Update example of external config to fix template_args not working

### DIFF
--- a/base/config/example_external_config.toml
+++ b/base/config/example_external_config.toml
@@ -28,6 +28,6 @@ import = "snippets/groups_forcerule.toml"
 #[[rulesets]]
 #import = ""
 
-[[template_args]]
+[[custom.template_args]]
 key = "clash.dns.port"
 value = "5353"


### PR DESCRIPTION
Toml are getting template_args with `custom.template_args` instead of `root.template_args`. 

Considering the logic has been over two years, changing only example files as documentation to avoid breaking change

#577 