### PR TITLE
Set most node_pref settings to indeterminate by default

### DIFF
--- a/base/pref.example.toml
+++ b/base/pref.example.toml
@@ -117,10 +117,10 @@ match = '^Smart Access expire: (\d+)/(\d+)/(\d+)$'
 replace = '$1:$2:$3:0:0:0'
 
 [node_pref]
-udp_flag = true
-tcp_fast_open_flag = false
-skip_cert_verify_flag = true
-tls13_flag = false
+#udp_flag = false
+#tcp_fast_open_flag = false
+#skip_cert_verify_flag = false
+#tls13_flag = false
 
 sort_flag = false
 # Script used for sorting nodes. A "compare" function with 2 arguments which are the 2 nodes to be compared should be defined in the script. Supports inline script and script path.


### PR DESCRIPTION
Settings within `node_pref` should be established with a thorough understanding of the subscription sources' configurations.
Additionally, defaulting `skip_cert_verify_flag` to true exposes security risks.

Since `pref.example.toml` serves as the default configuration file, it is suggested to reset these settings. Also moving us toward Secure-by-Default.