### PR TITLE
docs: Add instruction for furture contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,19 @@ subconverter.exe
 cmake-build-debug
 .idea
 base/cache
+
+# Build files
+/CmakeFiles
+/CMakeCache.txt
+/Makefile
+/cmake_install.cmake
+/tmp
+/subconverter
+
+# Dependencies for development
+/curl
+/libcron
+/quickjspp
+/toml11
+/yaml-cpp
+/rapidjson

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to Subconverter
+
+Welcome, and thank you for your interest in contributing to subconverter!
+
+## Reporting Issues
+
+- Check if the issue already exists.
+- Use the issue template to create a new issue.
+- Be as detailed as possible.
+
+## Feature Requests
+
+- Check the feature doesn't already exist.
+- Use the feature request template to submit a new request.
+
+## Pull Requests
+
+- Fork the repository.
+- Create a new branch for your changes.
+- Follow the coding style and guidelines.
+- Test the features as much as you can.
+- Update the documentation as needed.
+- Submit a pull request with a detailed description of your changes.
+
+## Setting Up Your Development Environment
+
+To contribute to Subconverter, you'll need to set up your development environment. Here's a brief overview:
+
+### Windows Build Instructions
+
+1. install the prerequisites:
+for example if you are using msys2 and mingw-w64 for compilation:
+```shell
+pacman -S base-devel git mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-pcre2 patch python
+```
+
+2. run script to initialize the project for development:
+```shell
+sh scripts/dev.windows.release.sh
+```
+
+3. debug the project with GDB:
+```shell
+gdb ./subconverter/subconverter.exe
+```
+or use VSCode with the following configuration:
+```json
+{
+    "name": "C/C++: g++.exe build and debug active file",
+    "type": "cppdbg",
+    "request": "launch",
+    "program": "${workspaceFolder}/subconverter/subconverter.exe",
+    "args": [],
+    "stopAtEntry": false,
+    "cwd": "${workspaceFolder}/subconverter/",
+    "environment": [],
+    "externalConsole": true,
+    "MIMode": "gdb",
+    "miDebuggerPath": "C:\\msys64\\mingw64\\bin\\gdb.exe",
+    "setupCommands": [
+        {
+        "description": "Enable pretty-printing for gdb",
+        "text": "-enable-pretty-printing",
+        "ignoreFailures": true
+        },
+        {
+        "description": "Set Disassembly Flavor to Intel",
+        "text": "-gdb-set disassembly-flavor intel",
+        "ignoreFailures": true
+        }
+    ],
+}
+```
+
+4. increamental build during development:
+
+```shell
+make -j4 && cp subconverter.exe subconverter/subconverter.exe
+```
+
+### Linux / macOS
+
+1. install the prerequisites:
+
+You should install all the following prequisites via your package manager.
+- cmake
+- pcre2
+- patch
+- python
+
+2. run the script to initialize the project for development:
+
+```shell
+sh scripts/build.macos.release.sh
+```
+
+3. run the executable for test:
+```shell
+./subconverter
+```
+
+Thank you for contributing to subconverter!

--- a/scripts/dev.windows.release.sh
+++ b/scripts/dev.windows.release.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -xe
+# remove all old deps
+rm -rf curl libcron quickjspp rapidjson toml11 yaml-cpp
+# remove tmp folder
+rm -rf tmp
+
+git clone https://github.com/curl/curl --depth=1 --branch curl-8_4_0
+cd curl
+cmake -DCMAKE_BUILD_TYPE=Debug -DCURL_USE_LIBSSH2=OFF -DHTTP_ONLY=ON -DCURL_USE_SCHANNEL=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_CURL_EXE=OFF -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX" -G "Unix Makefiles" -DHAVE_LIBIDN2=OFF -DCURL_USE_LIBPSL=OFF .
+make install -j4
+cd ..
+
+git clone https://github.com/jbeder/yaml-cpp --depth=1
+cd yaml-cpp
+cmake -DCMAKE_BUILD_TYPE=Debug -DYAML_CPP_BUILD_TESTS=OFF -DYAML_CPP_BUILD_TOOLS=OFF -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX" -G "Unix Makefiles" .
+make install -j4
+cd ..
+
+git clone https://github.com/ftk/quickjspp --depth=1
+cd quickjspp
+patch quickjs/quickjs-libc.c -i ../scripts/patches/0001-quickjs-libc-add-realpath-for-Windows.patch
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug .
+make quickjs -j4
+install -d "$MINGW_PREFIX/lib/quickjs/"
+install -m644 quickjs/libquickjs.a "$MINGW_PREFIX/lib/quickjs/"
+install -d "$MINGW_PREFIX/include/quickjs"
+install -m644 quickjs/quickjs.h quickjs/quickjs-libc.h "$MINGW_PREFIX/include/quickjs/"
+install -m644 quickjspp.hpp "$MINGW_PREFIX/include/"
+cd ..
+
+git clone https://github.com/PerMalmberg/libcron --depth=1
+cd libcron
+git submodule update --init
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX" .
+make libcron install -j4
+cd ..
+
+git clone https://github.com/Tencent/rapidjson --depth=1
+cd rapidjson
+cmake -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX" -G "Unix Makefiles" .
+make install -j4
+cd ..
+
+git clone https://github.com/ToruNiina/toml11 --depth=1
+cd toml11
+cmake -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX" -G "Unix Makefiles" -DCMAKE_CXX_STANDARD=11 .
+make install -j4
+cd ..
+
+python -m ensurepip
+python -m pip install gitpython
+python scripts/update_rules.py -c scripts/rules_config.conf
+
+rm -f C:/Strawberry/perl/bin/pkg-config C:/Strawberry/perl/bin/pkg-config.bat
+cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .
+make -j4
+rm subconverter.exe
+# shellcheck disable=SC2046
+g++ $(find CMakeFiles/subconverter.dir/src -name "*.obj") curl/lib/libcurl-d.a -o base/subconverter.exe -static -lbcrypt -lpcre2-8 -l:quickjs/libquickjs.a -llibcron -lyaml-cpp -liphlpapi -lcrypt32 -lws2_32 -lwsock32 -lz -s
+cp -rf base subconverter


### PR DESCRIPTION
For it may block potential contributors like this issue, https://github.com/tindy2013/subconverter/issues/685
I prefer to share my build experience by documents.