### PR TITLE
feat: add hysteria & hysteria 2 support  添加hysteria/ hysteria 2 支持

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -116,15 +116,19 @@ bool applyMatcher(const std::string &rule, std::string &real_rule, const Proxy &
     std::string target, ret_real_rule;
     static const std::string groupid_regex = R"(^!!(?:GROUPID|INSERT)=([\d\-+!,]+)(?:!!(.*))?$)", group_regex = R"(^!!(?:GROUP)=(.+?)(?:!!(.*))?$)";
     static const std::string type_regex = R"(^!!(?:TYPE)=(.+?)(?:!!(.*))?$)", port_regex = R"(^!!(?:PORT)=(.+?)(?:!!(.*))?$)", server_regex = R"(^!!(?:SERVER)=(.+?)(?:!!(.*))?$)";
-    static const std::map<ProxyType, const char *> types = {{ProxyType::Shadowsocks,  "SS"},
-                                                            {ProxyType::ShadowsocksR, "SSR"},
-                                                            {ProxyType::VMess,        "VMESS"},
-                                                            {ProxyType::Trojan,       "TROJAN"},
-                                                            {ProxyType::Snell,        "SNELL"},
-                                                            {ProxyType::HTTP,         "HTTP"},
-                                                            {ProxyType::HTTPS,        "HTTPS"},
-                                                            {ProxyType::SOCKS5,       "SOCKS5"},
-                                                            {ProxyType::WireGuard,    "WIREGUARD"}};
+    static const std::map<ProxyType, const char *> types = {
+        {ProxyType::Shadowsocks,  "SS"},
+        {ProxyType::ShadowsocksR, "SSR"},
+        {ProxyType::VMess,        "VMESS"},
+        {ProxyType::Trojan,       "TROJAN"},
+        {ProxyType::Snell,        "SNELL"},
+        {ProxyType::HTTP,         "HTTP"},
+        {ProxyType::HTTPS,        "HTTPS"},
+        {ProxyType::SOCKS5,       "SOCKS5"},
+        {ProxyType::WireGuard,    "WIREGUARD"},
+        {ProxyType::Hysteria,     "HYSTERIA"},
+        {ProxyType::Hysteria2,    "HYSTERIA2"}
+    };
     if(startsWith(rule, "!!GROUP="))
     {
         regGetMatch(rule, group_regex, 3, 0, &target, &ret_real_rule);
@@ -465,6 +469,77 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
                 singleproxy["dns"] = x.DnsServers;
             if(x.Mtu > 0)
                 singleproxy["mtu"] = x.Mtu;
+            break;
+        case ProxyType::Hysteria:
+            singleproxy["type"] = "hysteria";
+            if (!x.Ports.empty())
+                singleproxy["ports"] = x.Ports;
+            if (!x.Protocol.empty())
+                singleproxy["protocol"] = x.Protocol;
+            if (!x.OBFSParam.empty())
+                singleproxy["obfs-protocol"] = x.OBFSParam;
+            if (!x.Up.empty())
+                singleproxy["up"] = x.Up;
+            if (x.UpSpeed)
+                singleproxy["up-speed"] = x.UpSpeed;
+            if (!x.Down.empty())
+                singleproxy["down"] = x.Down;
+            if (x.DownSpeed)
+                singleproxy["down-speed"] = x.DownSpeed;
+            if (!x.AuthStr.empty())
+            {
+                singleproxy["auth-str"] = x.AuthStr;
+                singleproxy["auth"] = base64Encode(x.AuthStr);
+            }
+            if (!x.OBFS.empty())
+                singleproxy["obfs"] = x.OBFS;
+            if (!x.SNI.empty())
+                singleproxy["sni"] = x.SNI;
+            if (!scv.is_undef())
+                singleproxy["skip-cert-verify"] = scv.get();
+            if (!x.Fingerprint.empty())
+                singleproxy["fingerprint"] = x.Fingerprint;
+            if (!x.Alpn.empty())
+                singleproxy["alpn"] = x.Alpn;
+            if (!x.Ca.empty())
+                singleproxy["ca-str"] = fileGet(x.Ca);
+            if (!x.CaStr.empty())
+                singleproxy["ca-str"] = x.CaStr;
+            if (x.RecvWindowConn)
+                singleproxy["recv-window-conn"] = x.RecvWindowConn;
+            if (x.RecvWindow)
+                singleproxy["recv-window"] = x.RecvWindow;
+            if (!x.DisableMtuDiscovery.is_undef())
+                singleproxy["disable-mtu-discovery"] = x.DisableMtuDiscovery.get();
+            if (!x.TCPFastOpen.is_undef())
+                singleproxy["fast-open"] = x.TCPFastOpen.get();
+            if (x.HopInterval)
+                singleproxy["hop-interval"] = x.HopInterval;
+            break;
+        case ProxyType::Hysteria2:
+            singleproxy["type"] = "hysteria2";
+            if (!x.Up.empty())
+                singleproxy["up"] = x.UpSpeed;
+            if (!x.Down.empty())
+                singleproxy["down"] = x.DownSpeed;
+            if (!x.Password.empty())
+                singleproxy["password"] = x.Password;
+            if (!x.OBFS.empty())
+                singleproxy["obfs"] = x.OBFS;
+            if (!x.OBFSParam.empty())
+                singleproxy["obfs-password"] = x.OBFSParam;
+            if (!x.SNI.empty())
+                singleproxy["sni"] = x.SNI;
+            if (!scv.is_undef())
+                singleproxy["skip-cert-verify"] = scv.get();
+            if (!x.Alpn.empty())
+                singleproxy["alpn"] = x.Alpn;
+            if (!x.Ca.empty())
+                singleproxy["ca-str"] = fileGet(x.Ca);
+            if (!x.CaStr.empty())
+                singleproxy["ca-str"] = x.CaStr;
+            if (x.CWND)
+                singleproxy["cwnd"] = x.CWND;
             break;
         default:
             continue;
@@ -833,6 +908,20 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             if(x.KeepAlive > 0)
                 ini.set(real_section, "keepalive", std::to_string(x.KeepAlive));
             ini.set(real_section, "peer", "(" + generatePeer(x) + ")");
+            break;
+        case ProxyType::Hysteria2:
+            if(surge_ver < 5)
+                continue;
+            proxy = "hysteria, " + hostname + ", " + port + ", password=" + password;
+            if(x.DownSpeed)
+                proxy += ", download-bandwidth=" + x.DownSpeed;
+            
+            if(!scv.is_undef())
+                proxy += ",skip-cert-verify=" + std::string(scv.get() ? "true" : "false");
+            if(!x.Fingerprint.empty())
+                proxy += ",server-cert-fingerprint-sha256=" + x.Fingerprint;
+            if(!x.SNI.empty())
+                proxy += ",sni=" + x.SNI;
             break;
         default:
             continue;
@@ -2223,6 +2312,89 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
                 peers.PushBack(peer, allocator);
                 proxy.AddMember("peers", peers, allocator);
                 proxy.AddMember("mtu", x.Mtu, allocator);
+                break;
+            }
+            case ProxyType::Hysteria:
+            {
+                addSingBoxCommonMembers(proxy, x, "hysteria", allocator);
+                if (!x.Up.empty())
+                    proxy.AddMember("up", rapidjson::StringRef(x.Up.c_str()), allocator);
+                if (!x.Down.empty())
+                    proxy.AddMember("down", rapidjson::StringRef(x.Down.c_str()), allocator);
+                if (!x.OBFS.empty())
+                {
+                    proxy.AddMember("obfs", rapidjson::StringRef(x.OBFS.c_str()), allocator);
+                }
+                
+                if (!x.AuthStr.empty())
+                {
+                    proxy.AddMember("auth_str", rapidjson::StringRef(x.AuthStr.c_str()), allocator);
+                    std::string auth_str = base64Encode(x.AuthStr);
+                    proxy.AddMember("auth",rapidjson::StringRef(auth_str.c_str()), allocator);
+                }
+                if (x.RecvWindowConn)
+                    proxy.AddMember("recv_window_conn", x.RecvWindowConn, allocator);
+                if (x.RecvWindow)
+                    proxy.AddMember("recv_window", x.RecvWindow, allocator);
+                if (!x.DisableMtuDiscovery.is_undef())
+                    proxy.AddMember("disable_mtu_discovery", x.DisableMtuDiscovery.get(), allocator);
+                
+                rapidjson::Value tls(rapidjson::kObjectType);
+                tls.AddMember("enabled", true, allocator);
+                if (!scv.is_undef())
+                    tls.AddMember("insecure", scv.get(), allocator);
+                if (!x.Alpn.empty())
+                {
+                    rapidjson::Value alpn(rapidjson::kArrayType);
+                    alpn.PushBack(rapidjson::StringRef(x.Alpn.c_str()), allocator);
+                    tls.AddMember("alpn", alpn, allocator);
+                }
+                if (!x.Ca.empty())
+                {
+                    std::string ca_str = fileGet(x.Ca);
+                    tls.AddMember("certificate", rapidjson::StringRef(ca_str.c_str()), allocator);
+                }
+                if (!x.CaStr.empty())
+                    tls.AddMember("certificate", rapidjson::StringRef(x.CaStr.c_str()), allocator);
+                proxy.AddMember("tls", tls, allocator);
+                break;
+            }
+            case ProxyType::Hysteria2:
+            {
+                addSingBoxCommonMembers(proxy, x, "hysteria2", allocator);
+                if (!x.Up.empty())
+                    proxy.AddMember("up_mbps", x.UpSpeed, allocator);
+                if (!x.Down.empty())
+                    proxy.AddMember("down_mbps", x.DownSpeed, allocator);
+                if (!x.OBFS.empty())
+                {
+                    rapidjson::Value obfs(rapidjson::kObjectType);
+                    obfs.AddMember("type", rapidjson::StringRef(x.OBFS.c_str()), allocator);
+                    if (!x.OBFSParam.empty())
+                        obfs.AddMember("password", rapidjson::StringRef(x.OBFSParam.c_str()), allocator);
+                    proxy.AddMember("obfs", obfs, allocator);
+                }
+                if (!x.Password.empty())
+                    proxy.AddMember("password", rapidjson::StringRef(x.Password.c_str()), allocator);
+                
+                rapidjson::Value tls(rapidjson::kObjectType);
+                tls.AddMember("enabled", true, allocator);
+                if (!scv.is_undef())
+                    tls.AddMember("insecure", scv.get(), allocator);
+                if (!x.Alpn.empty())
+                {
+                    rapidjson::Value alpn(rapidjson::kArrayType);
+                    alpn.PushBack(rapidjson::StringRef(x.Alpn.c_str()), allocator);
+                    tls.AddMember("alpn", alpn, allocator);
+                }
+                if (!x.Ca.empty())
+                {
+                    std::string ca_str = fileGet(x.Ca);
+                    tls.AddMember("certificate", rapidjson::StringRef(ca_str.c_str()), allocator);
+                }
+                if (!x.CaStr.empty())
+                    tls.AddMember("certificate", rapidjson::StringRef(x.CaStr.c_str()), allocator);
+                proxy.AddMember("tls", tls, allocator);
                 break;
             }
             case ProxyType::HTTP:

--- a/src/parser/config/proxy.h
+++ b/src/parser/config/proxy.h
@@ -20,7 +20,9 @@ enum class ProxyType
     HTTP,
     HTTPS,
     SOCKS5,
-    WireGuard
+    WireGuard,
+    Hysteria,
+    Hysteria2
 };
 
 inline String getProxyTypeName(ProxyType type)
@@ -43,6 +45,12 @@ inline String getProxyTypeName(ProxyType type)
         return "HTTPS";
     case ProxyType::SOCKS5:
         return "SOCKS5";
+    case ProxyType::WireGuard:
+        return "WireGuard";
+    case ProxyType::Hysteria:
+        return "Hysteria";
+    case ProxyType::Hysteria2:
+        return "Hysteria2";
     default:
         return "Unknown";
     }
@@ -99,6 +107,24 @@ struct Proxy
     uint16_t KeepAlive = 0;
     String TestUrl;
     String ClientId;
+
+    String Ports;
+    String Up;
+    uint32_t UpSpeed;
+    String Down;
+    uint32_t DownSpeed;
+    String AuthStr;
+    String SNI;
+    String Fingerprint;
+    String Ca;
+    String CaStr;
+    uint32_t RecvWindowConn;
+    uint32_t RecvWindow;
+    tribool DisableMtuDiscovery;
+    uint32_t HopInterval;
+    String Alpn;
+
+    uint32_t CWND = 0;
 };
 
 #define SS_DEFAULT_GROUP "SSProvider"
@@ -109,5 +135,7 @@ struct Proxy
 #define TROJAN_DEFAULT_GROUP "TrojanProvider"
 #define SNELL_DEFAULT_GROUP "SnellProvider"
 #define WG_DEFAULT_GROUP "WireGuardProvider"
+#define HYSTERIA_DEFAULT_GROUP "HysteriaProvider"
+#define HYSTERIA2_DEFAULT_GROUP "Hysteria2Provider"
 
 #endif // PROXY_H_INCLUDED

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -130,6 +130,73 @@ void wireguardConstruct(Proxy &node, const std::string &group, const std::string
     node.ClientId = clientId;
 }
 
+void hysteriaConstruct(
+    Proxy &node,
+    const std::string &group,
+    const std::string &remarks,
+    const std::string &server,
+    const std::string &port,
+    const std::string &ports,
+    const std::string &protocol,
+    const std::string &obfs_protocol,
+    const std::string &up,
+    const std::string &up_speed,
+    const std::string &down,
+    const std::string &down_speed,
+    const std::string &auth,
+    const std::string &auth_str,
+    const std::string &obfs,
+    const std::string &sni,
+    const std::string &fingerprint,
+    const std::string &ca,
+    const std::string &ca_str,
+    const std::string &recv_window_conn,
+    const std::string &recv_window,
+    const std::string &disable_mtu_discovery,
+    const std::string &hop_interval,
+    const std::string &alpn,
+    tribool tfo,
+    tribool scv
+) {
+    commonConstruct(node, ProxyType::Hysteria, group, remarks, server, port, tribool(), tfo, scv, tribool());
+    node.Ports = ports;
+    node.Protocol = protocol;
+    node.OBFSParam = obfs_protocol;
+    node.Up = up;
+    node.UpSpeed = to_int(up_speed);
+    node.Down = down;
+    node.DownSpeed = to_int(down_speed);
+    node.AuthStr = auth_str;
+    if (!auth.empty())
+        node.AuthStr = base64Decode(auth);
+    node.OBFS = obfs;
+    node.SNI = sni;
+    node.Fingerprint = fingerprint;
+    node.Ca = ca;
+    node.CaStr = ca_str;
+    node.RecvWindowConn = to_int(recv_window_conn);
+    node.RecvWindow = to_int(recv_window);
+    node.DisableMtuDiscovery = disable_mtu_discovery;
+    node.HopInterval = to_int(hop_interval);
+    node.Alpn = alpn;
+}
+
+void hysteria2Construct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &server, const std::string &port,const std::string &up, const std::string &down, const std::string &password, const std::string &obfs, const std::string &obfs_password, const std::string &sni, const std::string &fingerprint, const std::string &alpn, const std::string &ca, const std::string &ca_str, const std::string &cwnd, tribool tfo, tribool scv) {
+    commonConstruct(node, ProxyType::Hysteria2, group, remarks, server, port, tribool(), tfo, scv, tribool());
+    node.UpSpeed = to_int(up);
+    node.DownSpeed = to_int(down);
+    node.Password = password;
+    node.OBFS = obfs;
+    node.OBFSParam = obfs_password;
+    node.SNI = sni;
+    node.Fingerprint = fingerprint;
+    node.Alpn = alpn;
+    node.Ca = ca;
+    node.CaStr = ca_str;
+    node.CWND = to_int(cwnd);
+
+}
+
 void explodeVmess(std::string vmess, Proxy &node)
 {
     std::string version, ps, add, port, type, id, aid, net, path, host, tls, sni;
@@ -979,6 +1046,8 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
     std::string protocol, protoparam, obfs, obfsparam; //ssr
     std::string user; //socks
     std::string ip, ipv6, private_key, public_key, mtu; //wireguard
+    std::string ports, obfs_protocol, up, up_speed, down, down_speed, auth, auth_str,/* obfs, sni,*/ fingerprint, ca, ca_str, recv_window_conn, recv_window, disable_mtu_discovery, hop_interval, alpn; //hysteria
+    std::string obfs_password, cwnd; //hysteria2
     string_array dns_server;
     tribool udp, tfo, scv;
     Node singleproxy;
@@ -995,6 +1064,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
         if(port.empty() || port == "0")
             continue;
         udp = safe_as<std::string>(singleproxy["udp"]);
+        tfo = safe_as<std::string>(singleproxy["fast-open"]);
         scv = safe_as<std::string>(singleproxy["skip-cert-verify"]);
         switch(hash_(proxytype))
         {
@@ -1190,6 +1260,49 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
 
             wireguardConstruct(node, group, ps, server, port, ip, ipv6, private_key, public_key, password, dns_server, mtu, "0", "", "", udp);
             break;
+        case "hysteria"_hash:
+            group = HYSTERIA_DEFAULT_GROUP;
+            singleproxy["ports"] >>= ports;
+            singleproxy["protocol"] >>= protocol;
+            singleproxy["obfs-protocol"] >>= obfs_protocol;
+            singleproxy["up"] >>= up;
+            singleproxy["up-speed"] >>= up_speed;
+            singleproxy["down"] >>= down;
+            singleproxy["down-speed"] >>= down_speed;
+            singleproxy["auth"] >>= auth;
+            singleproxy["auth_str"] >>= auth_str;
+            singleproxy["obfs"] >>= obfs;
+            singleproxy["sni"] >>= sni;
+            singleproxy["fingerprint"] >>= fingerprint;
+            singleproxy["alpn"] >>= alpn;
+            singleproxy["ca"] >>= ca;
+            singleproxy["ca-str"] >>= ca_str;
+            singleproxy["recv-window-conn"] >>= recv_window_conn;
+            singleproxy["recv-window"] >>= recv_window;
+            singleproxy["disable-mtu-discovery"] >>= disable_mtu_discovery;
+            singleproxy["hop-interval"] >>= hop_interval;
+
+            hysteriaConstruct(node, group, ps, server, port, ports, protocol, obfs_protocol, up, up_speed, down, down_speed, auth, auth_str, obfs, sni, fingerprint, ca, ca_str, recv_window_conn, recv_window, disable_mtu_discovery, hop_interval, alpn, tfo, scv);
+            break;
+        case "hysteria2"_hash:
+            group = HYSTERIA2_DEFAULT_GROUP;
+            singleproxy["up"] >>= up;
+            singleproxy["down"] >>= down;
+            singleproxy["password"] >>= password;
+            if (password.empty())
+                singleproxy["auth"] >>= password; 
+            singleproxy["obfs"] >>= obfs;
+            singleproxy["obfs-password"] >>= obfs_password;
+            singleproxy["sni"] >>= sni;
+            singleproxy["fingerprint"] >>= fingerprint;
+            singleproxy["alpn"] >>= alpn;
+            singleproxy["ca"] >>= ca;
+            singleproxy["ca-str"] >>= ca_str;
+            singleproxy["cwnd"] >>= cwnd;
+
+            hysteria2Construct(node, group, ps, server, port, up, down, password, obfs, obfs_password, sni, fingerprint, alpn, ca, ca_str, cwnd, tfo, scv );
+            break;
+
         default:
             continue;
         }
@@ -1323,6 +1436,68 @@ void explodeKitsunebi(std::string kit, Proxy &node)
         remarks = add + ":" + port;
 
     vmessConstruct(node, V2RAY_DEFAULT_GROUP, remarks, add, port, type, id, aid, net, cipher, path, host, "", tls, "");
+}
+
+
+void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
+    std::string add, port, password, host, insecure, up, down, alpn, obfs, obfs_password, remarks, sni, fingerprint;
+    std::string addition;
+    tribool scv;
+    hysteria2 = hysteria2.substr(12);
+    string_size pos;
+
+    pos = hysteria2.rfind("#");
+    if (pos != hysteria2.npos) {
+        remarks = urlDecode(hysteria2.substr(pos + 1));
+        hysteria2.erase(pos);
+    }
+
+    pos = hysteria2.rfind("?");
+    if (pos != hysteria2.npos) {
+        addition = hysteria2.substr(pos + 1);
+        hysteria2.erase(pos);
+    }
+
+    if (strFind(hysteria2, "@")) {
+        if (regGetMatch(hysteria2, R"(^(.*?)@(.*)[:](\d+)$)", 4, 0, &password, &add, &port))
+            return;
+    } else {
+        password = getUrlArg(addition, "password");
+        if (password.empty())
+            return;
+
+        if (!strFind(hysteria2, ":"))
+            return;
+
+        if (regGetMatch(hysteria2, R"(^(.*)[:](\d+)$)", 3, 0, &add, &port))
+            return;
+    }
+
+    scv = getUrlArg(addition, "insecure");
+    up = getUrlArg(addition, "up");
+    down = getUrlArg(addition, "down");
+    // the alpn is not supported officially yet
+    alpn = getUrlArg(addition, "alpn");
+    obfs = getUrlArg(addition, "obfs");
+    obfs_password = getUrlArg(addition, "obfs-password");
+    sni = getUrlArg(addition, "sni");
+    fingerprint = getUrlArg(addition, "pinSHA256");
+    if (remarks.empty())
+        remarks = add + ":" + port;
+
+    hysteria2Construct(node, HYSTERIA2_DEFAULT_GROUP, remarks, add, port, up, down, password, obfs, obfs_password, sni, fingerprint, "", "", "", "", tribool(), scv);
+    return;
+}
+
+void explodeHysteria2(std::string hysteria2, Proxy &node) {
+    hysteria2 = regReplace(hysteria2, "(hysteria2|hy2)://", "hysteria2://");
+
+    // replace /? with ?
+    hysteria2 = regReplace(hysteria2, "/\\?", "?", true, false);
+    if (regMatch(hysteria2, "hysteria2://(.*?)[:](.*)")) {
+        explodeStdHysteria2(hysteria2, node);
+        return;
+    }
 }
 
 // peer = (public-key = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=, allowed-ips = "0.0.0.0/0, ::/0", endpoint = engage.cloudflareclient.com:2408, client-id = 139/184/125),(public-key = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=, endpoint = engage.cloudflareclient.com:2408)
@@ -2220,6 +2395,8 @@ void explode(const std::string &link, Proxy &node)
         explodeNetch(link, node);
     else if(startsWith(link, "trojan://"))
         explodeTrojan(link, node);
+    else if (strFind(link, "hysteria2://") || strFind(link, "hy2://"))
+        explodeHysteria2(link, node);
     else if(isLink(link))
         explodeHTTPSub(link, node);
 }

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1270,7 +1270,9 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             singleproxy["down"] >>= down;
             singleproxy["down-speed"] >>= down_speed;
             singleproxy["auth"] >>= auth;
-            singleproxy["auth_str"] >>= auth_str;
+            singleproxy["auth-str"] >>= auth_str;
+            if (auth_str.empty())
+                singleproxy["auth_str"] >>= auth_str;
             singleproxy["obfs"] >>= obfs;
             singleproxy["sni"] >>= sni;
             singleproxy["fingerprint"] >>= fingerprint;
@@ -1280,6 +1282,8 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             singleproxy["recv-window-conn"] >>= recv_window_conn;
             singleproxy["recv-window"] >>= recv_window;
             singleproxy["disable-mtu-discovery"] >>= disable_mtu_discovery;
+            if (disable_mtu_discovery.empty())
+                singleproxy["disable_mtu_discovery"] >>= disable_mtu_discovery;
             singleproxy["hop-interval"] >>= hop_interval;
 
             hysteriaConstruct(node, group, ps, server, port, ports, protocol, obfs_protocol, up, up_speed, down, down_speed, auth, auth_str, obfs, sni, fingerprint, ca, ca_str, recv_window_conn, recv_window, disable_mtu_discovery, hop_interval, alpn, tfo, scv);

--- a/src/parser/subparser.h
+++ b/src/parser/subparser.h
@@ -27,6 +27,38 @@ void socksConstruct(Proxy &node, const std::string &group, const std::string &re
 void httpConstruct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &server, const std::string &port, const std::string &username, const std::string &password, bool tls, tribool tfo = tribool(), tribool scv = tribool(), tribool tls13 = tribool());
 void trojanConstruct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &server, const std::string &port, const std::string &password, const std::string &network, const std::string &host, const std::string &path, bool tlssecure, tribool udp = tribool(), tribool tfo = tribool(), tribool scv = tribool(), tribool tls13 = tribool());
 void snellConstruct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &server, const std::string &port, const std::string &password, const std::string &obfs, const std::string &host, uint16_t version = 0, tribool udp = tribool(), tribool tfo = tribool(), tribool scv = tribool());
+
+void hysteriaConstruct(
+    Proxy &node, 
+    const std::string &group, 
+    const std::string &remarks, 
+    const std::string &server,
+    const std::string &port, 
+    const std::string &ports,
+    const std::string &protocol, 
+    const std::string &obfs_protocol, 
+    const std::string &up, 
+    const std::string &up_speed, 
+    const std::string &down, 
+    const std::string &down_speed, 
+    const std::string &auth, 
+    const std::string &auth_str, 
+    const std::string &obfs, 
+    const std::string &sni, 
+    const std::string &fingerprint, 
+    const std::string &ca, 
+    const std::string &ca_str, 
+    const std::string &recv_window_conn, 
+    const std::string &recv_window, 
+    const std::string &disable_mtu_discovery, 
+    const std::string &hop_interval, 
+    const string_array &alpn, 
+    tribool tfo, 
+    tribool scv
+);
+
+void hysteria2Construct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &server, const std::string &port,const std::string &up, const std::string &down, const std::string &password, const std::string &obfs, const std::string &obfs_password, const std::string &sni, const std::string &fingerprint, const string_array &alpn, const std::string &ca, const std::string &caStr, const std::string &cwnd, tribool tfo, tribool scv);
+
 void explodeVmess(std::string vmess, Proxy &node);
 void explodeSSR(std::string ssr, Proxy &node);
 void explodeSS(std::string ss, Proxy &node);
@@ -35,6 +67,8 @@ void explodeQuan(const std::string &quan, Proxy &node);
 void explodeStdVMess(std::string vmess, Proxy &node);
 void explodeShadowrocket(std::string kit, Proxy &node);
 void explodeKitsunebi(std::string kit, Proxy &node);
+void explodeHysteria2(std::string hysteria2, Proxy &node);
+
 /// Parse a link
 void explode(const std::string &link, Proxy &node);
 void explodeSSD(std::string link, std::vector<Proxy> &nodes);


### PR DESCRIPTION
Since clash has paused to maintain and the hysteria / hysteria2 protocols are widely used for new nerds, I add the partial hysteria/hysteria2 support for my own convertions.

related issues:

https://github.com/tindy2013/subconverter/issues/518
https://github.com/tindy2013/subconverter/issues/640

Currently it seems has no problem converting from clash.yml to clash/surge/singbox/surfboard.
