### PR TITLE
fix(generator/ruleconvert): clash rule-provider without `payload:`

### DIFF
--- a/src/generator/config/ruleconvert.cpp
+++ b/src/generator/config/ruleconvert.cpp
@@ -28,7 +28,7 @@ std::string convertRuleset(const std::string &content, int type)
     if(type == RULESET_SURGE)
         return content;
 
-    if(regFind(content, "^payload:\\r?\\n")) /// Clash
+    if(regFind(content, "^payload:\\r?\\n") || (type == RULESET_CLASH_DOMAIN || type == RULESET_CLASH_IPCIDR)) /// Clash
     {
         output = regReplace(regReplace(content, "payload:\\r?\\n", "", true), R"(\s?^\s*-\s+('|"?)(.*)\1$)", "\n$2", true);
         if(type == RULESET_CLASH_CLASSICAL) /// classical type

--- a/src/generator/config/ruleconvert.cpp
+++ b/src/generator/config/ruleconvert.cpp
@@ -53,15 +53,18 @@ std::string convertRuleset(const std::string &content, int type)
 
             if(!strLine.empty() && (strLine[0] != ';' && strLine[0] != '#' && !(lineSize >= 2 && strLine[0] == '/' && strLine[1] == '/')))
             {
-                pos = strLine.find('/');
-                if(pos != std::string::npos) /// ipcidr
+                if(type == RULESET_CLASH_IPCIDR)
                 {
-                    if(isIPv4(strLine.substr(0, pos)))
-                        output += "IP-CIDR,";
-                    else
-                        output += "IP-CIDR6,";
-                }
-                else
+                    pos = strLine.find('/');
+                    if(pos != std::string::npos) /// ipcidr
+                    {
+                        if(isIPv4(strLine.substr(0, pos)))
+                            output += "IP-CIDR,";
+                        else
+                            output += "IP-CIDR6,";
+                    }
+                } 
+                else if (type == RULESET_CLASH_DOMAIN)
                 {
                     if(strLine[0] == '.' || (lineSize >= 2 && strLine[0] == '+' && strLine[1] == '.')) /// suffix
                     {
@@ -81,6 +84,37 @@ std::string convertRuleset(const std::string &content, int type)
                     else
                         output += "DOMAIN,";
                 }
+                else
+                {
+                    pos = strLine.find('/');
+                    if(pos != std::string::npos) /// ipcidr
+                    {
+                        if(isIPv4(strLine.substr(0, pos)))
+                            output += "IP-CIDR,";
+                        else
+                            output += "IP-CIDR6,";
+                    }
+                    else
+                    {
+                        if(strLine[0] == '.' || (lineSize >= 2 && strLine[0] == '+' && strLine[1] == '.')) /// suffix
+                        {
+                            bool keyword_flag = false;
+                            while(endsWith(strLine, ".*"))
+                            {
+                                keyword_flag = true;
+                                strLine.erase(strLine.size() - 2);
+                            }
+                            output += "DOMAIN-";
+                            if(keyword_flag)
+                                output += "KEYWORD,";
+                            else
+                                output += "SUFFIX,";
+                            strLine.erase(0, 2 - (strLine[0] == '.'));
+                        }
+                        else
+                            output += "DOMAIN,";
+                    }
+                } 
             }
             output += strLine;
             output += '\n';


### PR DESCRIPTION
## what & why

#751 

## how

在判断 `payload:` 同级的位置增加 `type==RULESET_CLASH_DOMAIN` 或者 `type=RULESET_CLASH_IPCIDR`

并在确认 type 为 `clash-domain` 时仅仅解析为域名规则、在确认 type 为 `clash-ipcidr` 时仅仅解析为 IP 规则

## test

通过这个 [测试 config](https://gist.githubusercontent.com/ChrAlpha/25bd9c3f07b0b6848e26889583a8860a/raw/3a899bbe190b5d8cff30621e6f1f7babb458099f/gistfile1.txt)，无论是原本带 `payload:` 的 ruleset 和我希望修复的开头不带 `payload:` 的 ruleset 都能正常解析。

## btw

对行单独（用正则表达式）判断是否为域名或者 IP，并在 type 为 `clash-domain` 时候仅解析是域名的行（IP 同理），而非和原来一样通过 `DOMAIN,` 兜底一切行内容，或许会使程序更具鲁棒性。