### PR TITLE
fix: corrected Taiwan flag emoji

### DIFF
--- a/base/snippets/emoji.toml
+++ b/base/snippets/emoji.toml
@@ -8,7 +8,7 @@ emoji = "🇭🇰"
 
 [[emoji]]
 match = "(?i:\\bTW[N]?\\b|Taiwan|新北|彰化|\\bCHT\\b|台湾|[^-]台|\\bHINET\\b)"
-emoji = "🇨🇳"
+emoji = "🇹🇼"
 
 [[emoji]]
 match = "(?i:\\bSG[P]?\\b|Singapore|新加坡|狮城|[^-]新)"

--- a/base/snippets/emoji.txt
+++ b/base/snippets/emoji.txt
@@ -1,6 +1,6 @@
 (?i:Bandwidth|expire|流量|时间|应急|过期),🏳️‍🌈
 (?i:\bHK[G]?\b|Hong.*?Kong|\bHKT\b|\bHKBN\b|\bHGC\b|\bWTT\b|\bCMI\b|[^-]港),🇭🇰
-(?i:\bTW[N]?\b|Taiwan|新北|彰化|\bCHT\b|台湾|[^-]台|\bHINET\b),🇨🇳
+(?i:\bTW[N]?\b|Taiwan|新北|彰化|\bCHT\b|台湾|[^-]台|\bHINET\b),🇹🇼
 (?i:\bSG[P]?\b|Singapore|新加坡|狮城|[^-]新),🇸🇬
 (尼日利亚|Nigeria),🇳🇬
 (?i:\bJP[N]?\b|Japan|Tokyo|Osaka|Saitama|日本|东京|大阪|埼玉|[^-]日),🇯🇵


### PR DESCRIPTION
There should be a distinction between Taiwan and mainland flag emoji.