### PR TITLE
Feat(hysteria2): support hysteria2 port hopping for clash/singbox results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,22 +4,3 @@ cmake-build-debug
 .idea
 base/cache
 build
-
-# Build files
-/CMakeFiles
-/CMakeCache.txt
-/Makefile
-/cmake_install.cmake
-/tmp
-/subconverter
-/base/subconverter
-/base
-/*.a
-
-# Dependencies for development
-/curl
-/libcron
-/quickjspp
-/toml11
-/yaml-cpp
-/rapidjson

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,22 @@ cmake-build-debug
 .idea
 base/cache
 build
+
+# Build files
+/CMakeFiles
+/CMakeCache.txt
+/Makefile
+/cmake_install.cmake
+/tmp
+/subconverter
+/base/subconverter
+/base
+/*.a
+
+# Dependencies for development
+/curl
+/libcron
+/quickjspp
+/toml11
+/yaml-cpp
+/rapidjson

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -530,6 +530,8 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
             break;
         case ProxyType::Hysteria2:
             singleproxy["type"] = "hysteria2";
+            if (!x.Ports.empty())
+                singleproxy["ports"] = x.Ports;
             if (!x.Up.empty())
                 singleproxy["up"] = x.UpSpeed;
             if (!x.Down.empty())
@@ -552,6 +554,8 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
                 singleproxy["ca-str"] = x.CaStr;
             if (x.CWND)
                 singleproxy["cwnd"] = x.CWND;
+            if (x.HopInterval)
+                singleproxy["hop-interval"] = x.HopInterval;
             break;
         default:
             continue;
@@ -2395,6 +2399,8 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
             case ProxyType::Hysteria2:
             {
                 addSingBoxCommonMembers(proxy, x, "hysteria2", allocator);
+                if (!x.Ports.empty())
+                    proxy.AddMember("server_ports", stringArrayToJsonArray(x.Ports, ",", allocator), allocator);
                 if (!x.Up.empty())
                     proxy.AddMember("up_mbps", x.UpSpeed, allocator);
                 if (!x.Down.empty())
@@ -2409,7 +2415,8 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
                 }
                 if (!x.Password.empty())
                     proxy.AddMember("password", rapidjson::StringRef(x.Password.c_str()), allocator);
-                
+                if (x.HopInterval)
+                    proxy.AddMember("hop_interval", rapidjson::Value(formatSingBoxInterval(x.HopInterval).c_str(), allocator), allocator);
                 rapidjson::Value tls(rapidjson::kObjectType);
                 tls.AddMember("enabled", true, allocator);
                 if (!scv.is_undef())

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -159,7 +159,7 @@ void hysteriaConstruct(
     const std::string &alpn,
     tribool tfo,
     tribool scv,
-    const std::string &underlying_proxy = ""
+    const std::string &underlying_proxy
 ) {
     commonConstruct(node, ProxyType::Hysteria, group, remarks, server, port, tribool(), tfo, scv, tribool(), underlying_proxy);
     node.Ports = ports;
@@ -208,10 +208,33 @@ void hysteriaConstruct(
     }
 }
 
-void hysteria2Construct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &server, const std::string &port,const std::string &up, const std::string &down, const std::string &password, const std::string &obfs, const std::string &obfs_password, const std::string &sni, const std::string &fingerprint, const std::string &alpn, const std::string &ca, const std::string &ca_str, const std::string &cwnd, tribool tfo, tribool scv, const std::string &underlying_proxy) {
+void hysteria2Construct(
+    Proxy &node, 
+    const std::string &group,
+    const std::string &remarks,
+    const std::string &server, 
+    const std::string &port,
+    const std::string &ports,
+    const std::string &up, 
+    const std::string &down,
+    const std::string &password,
+    const std::string &obfs,
+    const std::string &obfs_password,
+    const std::string &sni,
+    const std::string &fingerprint,
+    const std::string &alpn,
+    const std::string &ca,
+    const std::string &caStr,
+    const std::string &cwnd,
+    const std::string &hop_interval, 
+    tribool tfo, 
+    tribool scv, 
+    const std::string &underlying_proxy
+) {
     commonConstruct(node, ProxyType::Hysteria2, group, remarks, server, port, tribool(), tfo, scv, tribool(), underlying_proxy);
     node.UpSpeed = to_int(up);
     node.DownSpeed = to_int(down);
+    node.Ports = ports;
     node.Password = password;
     node.OBFS = obfs;
     node.OBFSParam = obfs_password;
@@ -222,9 +245,9 @@ void hysteria2Construct(Proxy &node, const std::string &group, const std::string
         node.Alpn = StringArray {alpn};
     }
     node.Ca = ca;
-    node.CaStr = ca_str;
+    node.CaStr = caStr;
     node.CWND = to_int(cwnd);
-
+    node.HopInterval = to_int(hop_interval);
 }
 
 void explodeVmess(std::string vmess, Proxy &node)
@@ -1324,6 +1347,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             break;
         case "hysteria2"_hash:
             group = HYSTERIA2_DEFAULT_GROUP;
+            singleproxy["ports"] >>= ports;
             singleproxy["up"] >>= up;
             singleproxy["down"] >>= down;
             singleproxy["password"] >>= password;
@@ -1340,8 +1364,9 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             singleproxy["ca"] >>= ca;
             singleproxy["ca-str"] >>= ca_str;
             singleproxy["cwnd"] >>= cwnd;
+            singleproxy["hop-interval"] >>= hop_interval;
 
-            hysteria2Construct(node, group, ps, server, port, up, down, password, obfs, obfs_password, sni, fingerprint, alpn, ca, ca_str, cwnd, tfo, scv, underlying_proxy);
+            hysteria2Construct(node, group, ps, server, port, ports, up, down, password, obfs, obfs_password, sni, fingerprint, ca, ca_str, cwnd, alpn, hop_interval, tfo, scv, underlying_proxy);
             break;
 
         default:
@@ -1526,7 +1551,7 @@ void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
     if (remarks.empty())
         remarks = add + ":" + port;
 
-    hysteria2Construct(node, HYSTERIA2_DEFAULT_GROUP, remarks, add, port, up, down, password, obfs, obfs_password, sni, fingerprint, "", "", "", "", tribool(), scv, "");
+    hysteria2Construct(node, HYSTERIA2_DEFAULT_GROUP, remarks, add, port, port, up, down, password, obfs, obfs_password, sni, fingerprint, "", "", "", "", "", tribool(), scv, "");
     return;
 }
 

--- a/src/parser/subparser.h
+++ b/src/parser/subparser.h
@@ -52,13 +52,35 @@ void hysteriaConstruct(
     const std::string &recv_window, 
     const std::string &disable_mtu_discovery, 
     const std::string &hop_interval, 
-    const string_array &alpn, 
+    const std::string &alpn, 
     tribool tfo, 
     tribool scv,
     const std::string &underlying_proxy = ""
 );
 
-void hysteria2Construct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &server, const std::string &port,const std::string &up, const std::string &down, const std::string &password, const std::string &obfs, const std::string &obfs_password, const std::string &sni, const std::string &fingerprint, const string_array &alpn, const std::string &ca, const std::string &caStr, const std::string &cwnd, tribool tfo, tribool scv, const std::string &underlying_proxy = "");
+void hysteria2Construct(
+    Proxy &node, 
+    const std::string &group,
+    const std::string &remarks,
+    const std::string &server, 
+    const std::string &port,
+    const std::string &ports,
+    const std::string &up, 
+    const std::string &down,
+    const std::string &password,
+    const std::string &obfs,
+    const std::string &obfs_password,
+    const std::string &sni,
+    const std::string &fingerprint,
+    const std::string &alpn,
+    const std::string &ca,
+    const std::string &caStr,
+    const std::string &cwnd,
+    const std::string &hop_interval, 
+    tribool tfo, 
+    tribool scv, 
+    const std::string &underlying_proxy = ""
+);
 
 void explodeVmess(std::string vmess, Proxy &node);
 void explodeSSR(std::string ssr, Proxy &node);


### PR DESCRIPTION
### Summary
Add Hysteria2 port hopping configuration support for Clash and sing-box implementations.

### Description
This PR extends the existing port hopping functionality to include Hysteria2 proxies in both Clash.Mihomo and sing-box implementations. The update adds support for `server-ports` and `hop-interval` attributes, which were previously only available for Hysteria1.

### Technical Context
Both Clash.Mihomo and sing-box now fully support Hysteria2 port hopping functionality. This implementation aligns with their respective documentation and current codebase requirements.

### References
- Clash.Mihomo Hysteria2 Documentation: https://wiki.metacubex.one/en/config/inbound/listeners/hysteria2/
- Clash.Mihomo Implementation: https://github.com/MetaCubeX/mihomo/blob/Alpha/adapter/outbound/hysteria2.go
- sing-box Hysteria2 Configuration: https://sing-box.sagernet.org/zh/configuration/outbound/hysteria2/#server_ports
- sing-box Implementation: https://github.com/SagerNet/sing-box/blob/8cc7734a921bf6c24d52d3b8dc40a553a88d7f5a/option/hysteria2.go#L115-L116