### PR TITLE
Enhanced Profile Configuration Parsing and Tag Matching in profile.ini

### DIFF
--- a/src/generator/config/nodemanip.cpp
+++ b/src/generator/config/nodemanip.cpp
@@ -174,13 +174,13 @@ int addNodes(std::string link, std::vector<Proxy> &allNodes, int groupID, parse_
                 if(!getSubInfoFromHeader(extra_headers, subInfo))
                     getSubInfoFromNodes(nodes, stream_rules, time_rules, subInfo);
             }
-            filterNodes(nodes, exclude_remarks, include_remarks, groupID);
             for(Proxy &x : nodes)
             {
                 x.GroupId = groupID;
                 if(custom_group.size())
                     x.Group = custom_group;
             }
+            filterNodes(nodes, exclude_remarks, include_remarks, groupID);
             copyNodes(nodes, allNodes);
         }
         else
@@ -206,13 +206,13 @@ int addNodes(std::string link, std::vector<Proxy> &allNodes, int groupID, parse_
         {
             getSubInfoFromNodes(nodes, stream_rules, time_rules, subInfo);
         }
-        filterNodes(nodes, exclude_remarks, include_remarks, groupID);
         for(Proxy &x : nodes)
         {
             x.GroupId = groupID;
             if(!custom_group.empty())
                 x.Group = custom_group;
         }
+        filterNodes(nodes, exclude_remarks, include_remarks, groupID);
         copyNodes(nodes, allNodes);
         break;
     default:


### PR DESCRIPTION
1. exclude/include supports tag matching for "!!GROUP=", "!!GROUPID=", and "!!INSERT=".
(Also applicable to the exclude/include_remarks in the pref and external_config configuration files.)
2. exclude/include supports multiple expressions separated by the delimiter '`'.
3. Supports parsing multi-line contents for "url=", "rename=", and "exclude/include=" by merging them into a single line using delimiters.