### PR TITLE
Fix password parsing for SS2022 with special characters

### DIFF
--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -168,7 +168,7 @@ void hysteriaConstruct(
     if (!up.empty())
     {
         if (up.length() > 4 && up.find("bps") == up.length() - 3)
-        
+
             node.Up = up;
         else if (to_int(up))
         {
@@ -209,13 +209,13 @@ void hysteriaConstruct(
 }
 
 void hysteria2Construct(
-    Proxy &node, 
+    Proxy &node,
     const std::string &group,
     const std::string &remarks,
-    const std::string &server, 
+    const std::string &server,
     const std::string &port,
     const std::string &ports,
-    const std::string &up, 
+    const std::string &up,
     const std::string &down,
     const std::string &password,
     const std::string &obfs,
@@ -226,9 +226,9 @@ void hysteria2Construct(
     const std::string &ca,
     const std::string &caStr,
     const std::string &cwnd,
-    const std::string &hop_interval, 
-    tribool tfo, 
-    tribool scv, 
+    const std::string &hop_interval,
+    tribool tfo,
+    tribool scv,
     const std::string &underlying_proxy
 ) {
     commonConstruct(node, ProxyType::Hysteria2, group, remarks, server, port, tribool(), tfo, scv, tribool(), underlying_proxy);
@@ -945,7 +945,7 @@ void explodeQuan(const std::string &quan, Proxy &node)
         //read link
         for(uint32_t i = 6; i < configs.size(); i++)
         {
-            vArray = split(configs[i], "=");
+            vArray = splitKeyValue(configs[i], "=");
             if(vArray.size() < 2)
                 continue;
             itemName = trim(vArray[0]);
@@ -1352,7 +1352,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             singleproxy["down"] >>= down;
             singleproxy["password"] >>= password;
             if (password.empty())
-                singleproxy["auth"] >>= password; 
+                singleproxy["auth"] >>= password;
             singleproxy["obfs"] >>= obfs;
             singleproxy["obfs-password"] >>= obfs_password;
             singleproxy["sni"] >>= sni;
@@ -1685,7 +1685,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
             for(i = 6; i < configs.size(); i++)
             {
-                vArray = split(configs[i], "=");
+                vArray = splitKeyValue(configs[i], "=");
                 if(vArray.size() < 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -1728,7 +1728,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
             for(i = 3; i < configs.size(); i++)
             {
-                vArray = split(configs[i], "=");
+                vArray = splitKeyValue(configs[i], "=");
                 if(vArray.size() < 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -1778,7 +1778,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
             }
             for(i = 5; i < configs.size(); i++)
             {
-                vArray = split(configs[i], "=");
+                vArray = splitKeyValue(configs[i], "=");
                 if(vArray.size() < 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -1810,7 +1810,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
             for(i = 3; i < configs.size(); i++)
             {
-                vArray = split(configs[i], "=");
+                vArray = splitKeyValue(configs[i], "=");
                 if(vArray.size() != 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -1873,7 +1873,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
                 continue;
             for(i = 3; i < configs.size(); i++)
             {
-                vArray = split(configs[i], "=");
+                vArray = splitKeyValue(configs[i], "=");
                 if(vArray.size() < 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -1903,7 +1903,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
             for(i = 3; i < configs.size(); i++)
             {
-                vArray = split(configs[i], "=");
+                vArray = splitKeyValue(configs[i], "=");
                 if(vArray.size() != 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -1940,7 +1940,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
             for(i = 3; i < configs.size(); i++)
             {
-                vArray = split(configs[i], "=");
+                vArray = splitKeyValue(configs[i], "=");
                 if(vArray.size() != 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -1978,7 +1978,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
         case "wireguard"_hash:
             for (i = 1; i < configs.size(); i++)
             {
-                vArray = split(trim(configs[i]), "=");
+                vArray = splitKeyValue(trim(configs[i]), "=");
                 if(vArray.size() != 2)
                     continue;
                 itemName = trim(vArray[0]);
@@ -2045,7 +2045,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
                 for(i = 1; i < configs.size(); i++)
                 {
-                    vArray = split(trim(configs[i]), "=");
+                    vArray = splitKeyValue(trim(configs[i]), "=");
                     if(vArray.size() != 2)
                         continue;
                     itemName = trim(vArray[0]);
@@ -2146,7 +2146,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
                 for(i = 1; i < configs.size(); i++)
                 {
-                    vArray = split(trim(configs[i]), "=");
+                    vArray = splitKeyValue(trim(configs[i]), "=");
                     if(vArray.size() != 2)
                         continue;
                     itemName = trim(vArray[0]);
@@ -2214,7 +2214,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
                 for(i = 1; i < configs.size(); i++)
                 {
-                    vArray = split(trim(configs[i]), "=");
+                    vArray = splitKeyValue(trim(configs[i]), "=");
                     if(vArray.size() != 2)
                         continue;
                     itemName = trim(vArray[0]);
@@ -2262,7 +2262,7 @@ bool explodeSurge(std::string surge, std::vector<Proxy> &nodes)
 
                 for(i = 1; i < configs.size(); i++)
                 {
-                    vArray = split(trim(configs[i]), "=");
+                    vArray = splitKeyValue(trim(configs[i]), "=");
                     if(vArray.size() != 2)
                         continue;
                     itemName = trim(vArray[0]);

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -45,6 +45,34 @@ std::vector<std::string_view> split(std::string_view s, char separator)
     return result;
 }
 
+/**
+ * Split string at the first occurrence of separator only.
+ *
+ * This function is designed for parsing key-value pairs where the value
+ * may contain the separator character. For example, in SS2022 protocol,
+ * the password field may contain '=' characters that should not be treated
+ * as additional separators.
+ */
+std::vector<std::string> splitKeyValue(const std::string &s, const std::string &separator)
+{
+    std::vector<std::string> result;
+    string_size pos = s.find(separator);
+
+    if (pos == std::string::npos)
+    {
+        // No separator found, return the whole string
+        result.push_back(s);
+    }
+    else
+    {
+        // Split only at the first occurrence of separator
+        result.push_back(s.substr(0, pos));
+        result.push_back(s.substr(pos + separator.size()));
+    }
+
+    return result;
+}
+
 std::string UTF8ToCodePoint(const std::string &data)
 {
     std::stringstream ss;

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -18,6 +18,8 @@ using string_pair_array = std::vector<std::pair<std::string, std::string>>;
 std::vector<std::string> split(const std::string &s, const std::string &separator);
 std::vector<std::string_view> split(std::string_view s, char separator);
 void split(std::vector<std::string_view> &result, std::string_view s, char separator);
+// Split string at first separator only, useful for key-value pairs where value may contain separator
+std::vector<std::string> splitKeyValue(const std::string &s, const std::string &separator);
 std::string join(const string_array &arr, const std::string &delimiter);
 
 template <typename InputIt>


### PR DESCRIPTION
- Add `splitKeyValue()` function to split only at first separator

- Replace `split()` with `splitKeyValue()` for config key-value parsing

- Prevent truncation of password fields containing `=`

Fixes #838