### PR TITLE
Add embed_remote_rules flag, Stash export, Hysteria2 fix & extended extra-param handling

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -121,6 +121,7 @@
 | ---------------------- | :---: | :----: | -------------- |
 | Clash                  |   ✓   |    ✓   | clash          |
 | ClashR                 |   ✓   |    ✓   | clashr         |
+| Stash                  |   ✓   |    ✓   | stash         |
 | Quantumult (完整配置)      |   ✓   |    ✓   | quan           |
 | Quantumult X (完整配置)    |   ✓   |    ✓   | quanx          |
 | Loon                   |   ✓   |    ✓   | loon           |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Utility to convert between various proxy subscription formats.
 | ------------ | :--------: | :----------: | ----------- |
 | Clash        |     ✓      |      ✓       | clash       |
 | ClashR       |     ✓      |      ✓       | clashr      |
+| Stash        |     ✓      |      ✓       | stash      |
 | Quantumult   |     ✓      |      ✓       | quan        |
 | Quantumult X |     ✓      |      ✓       | quanx       |
 | Loon         |     ✓      |      ✓       | loon        |

--- a/base/base/all_base.tpl
+++ b/base/base/all_base.tpl
@@ -1,4 +1,4 @@
-{% if request.target == "clash" or request.target == "clashr" %}
+{% if request.target == "clash" or request.target == "clashr" or request.target == "stash" %}
 
 port: {{ default(global.clash.http_port, "7890") }}
 socks-port: {{ default(global.clash.socks_port, "7891") }}

--- a/base/pref.example.toml
+++ b/base/pref.example.toml
@@ -265,6 +265,10 @@ uri = "/clashr"
 target = "/sub?target=clashr"
 
 [[aliases]]
+uri = "/stash"
+target = "/sub?target=stash"
+
+[[aliases]]
 uri = "/surge"
 target = "/sub?target=surge"
 

--- a/base/pref.example.yml
+++ b/base/pref.example.yml
@@ -117,6 +117,7 @@ aliases:
   - {uri: /v, target: /version}
   - {uri: /clash, target: "/sub?target=clash"}
   - {uri: /clashr, target: "/sub?target=clashr"}
+  - {uri: /stash, target: "/sub?target=stash"}
   - {uri: /surge, target: "/sub?target=surge"}
   - {uri: /quan, target: "/sub?target=quan"}
   - {uri: /quanx, target: "/sub?target=quanx"}

--- a/include/quickjspp.hpp
+++ b/include/quickjspp.hpp
@@ -405,11 +405,14 @@ struct js_traits<std::variant<Ts...>>
                 return std::is_integral_v<T> || std::is_floating_point_v<T>;
             case JS_TAG_BOOL:
                 return is_boolean<T>::value || std::is_integral_v<T> || std::is_floating_point_v<T>;
-
+#ifdef JS_TAG_BIG_DECIMAL
             case JS_TAG_BIG_DECIMAL:
                 [[fallthrough]];
+#endif
+#ifdef JS_TAG_BIG_FLOAT
             case JS_TAG_BIG_FLOAT:
                 [[fallthrough]];
+#endif
             case JS_TAG_FLOAT64:
             default: // >JS_TAG_FLOAT64 (JS_NAN_BOXING)
                 return is_double<T>::value || std::is_floating_point_v<T>;
@@ -473,12 +476,14 @@ struct js_traits<std::variant<Ts...>>
                 [[fallthrough]];
             case JS_TAG_EXCEPTION:
                 break;
-
+#ifdef JS_TAG_BIG_DECIMAL
             case JS_TAG_BIG_DECIMAL:
                 [[fallthrough]];
+#endif
+#ifdef JS_TAG_BIG_FLOAT
             case JS_TAG_BIG_FLOAT:
                 [[fallthrough]];
-
+#endif
             case JS_TAG_FLOAT64:
                 [[fallthrough]];
             default: // more than JS_TAG_FLOAT64 (nan boxing)

--- a/src/config/binding.h
+++ b/src/config/binding.h
@@ -285,21 +285,37 @@ namespace INIBinding
                 if(pos == String::npos)
                     continue;
                 conf.Group = x.substr(0, pos);
-                if(x.substr(pos + 1, 2) == "[]")
+                String rest = x.substr(pos + 1);
+                if(rest.substr(0, 2) == "[]")
                 {
-                    conf.Url = x.substr(pos + 1);
-                    //conf.Type = RulesetType::SurgeRuleset;
+                    conf.Url = rest;
                     confs.emplace_back(std::move(conf));
                     continue;
                 }
-                String::size_type epos = x.rfind(",");
-                if(pos != epos)
+                String::size_type fpos = rest.rfind(",flags=");
+                if(fpos != String::npos)
                 {
-                    conf.Interval = to_int(x.substr(epos + 1), 0);
-                    conf.Url = x.substr(pos + 1, epos - pos - 1);
+                    String flags_part = rest.substr(fpos + 7);
+                    String::size_type ipos = flags_part.find(',');
+                    if(ipos != String::npos)
+                    {
+                        conf.Interval = to_int(flags_part.substr(ipos + 1), 0);
+                        conf.Url = rest.substr(0, fpos) + ",flags=" + flags_part.substr(0, ipos);
+                    }
+                    else
+                        conf.Url = rest;
                 }
                 else
-                    conf.Url = x.substr(pos + 1);
+                {
+                    String::size_type epos = rest.rfind(",");
+                    if(epos != String::npos)
+                    {
+                        conf.Interval = to_int(rest.substr(epos + 1), 0);
+                        conf.Url = rest.substr(0, epos);
+                    }
+                    else
+                        conf.Url = rest;
+                }
                 confs.emplace_back(std::move(conf));
             }
             return confs;

--- a/src/generator/config/ruleconvert.h
+++ b/src/generator/config/ruleconvert.h
@@ -24,6 +24,7 @@ struct RulesetContent
     std::string rule_group;
     std::string rule_path;
     std::string rule_path_typed;
+    std::string flags;
     int rule_type = RULESET_SURGE;
     std::shared_future<std::string> rule_content;
     int update_interval = 0;
@@ -32,7 +33,7 @@ struct RulesetContent
 std::string convertRuleset(const std::string &content, int type);
 void rulesetToClash(YAML::Node &base_rule, std::vector<RulesetContent> &ruleset_content_array, bool overwrite_original_rules, bool new_field_name);
 std::string rulesetToClashStr(YAML::Node &base_rule, std::vector<RulesetContent> &ruleset_content_array, bool overwrite_original_rules, bool new_field_name);
-void rulesetToSurge(INIReader &base_rule, std::vector<RulesetContent> &ruleset_content_array, int surge_ver, bool overwrite_original_rules, const std::string& remote_path_prefix);
+void rulesetToSurge(INIReader &base_rule, std::vector<RulesetContent> &ruleset_content_array, int surge_ver, bool overwrite_original_rules, const std::string& remote_path_prefix, bool embed_remote_rules);
 void rulesetToSingBox(rapidjson::Document &base_rule, std::vector<RulesetContent> &ruleset_content_array, bool overwrite_original_rules);
 
 #endif // RULECONVERT_H_INCLUDED

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -3,6 +3,8 @@
 #include <numeric>
 #include <cmath>
 #include <climits>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "config/regmatch.h"
 #include "generator/config/subexport.h"
@@ -58,6 +60,48 @@ std::string vmessLinkConstruct(const std::string &remarks, const std::string &ad
     writer.String(tls.data());
     writer.EndObject();
     return sb.GetString();
+}
+
+static YAML::Node buildEmbeddedProxy(const std::string &name,
+                                     const std::unordered_map<std::string, YAML::Node> &dict,
+                                     std::unordered_set<std::string> &visited)
+{
+    if(visited.count(name))
+        return YAML::Node();
+    auto it = dict.find(name);
+    if(it == dict.end())
+        return YAML::Node();
+    visited.insert(name);
+    YAML::Node node = YAML::Clone(it->second);
+    if(node["underlying-proxy"])
+    {
+        YAML::Node up = node["underlying-proxy"];
+        if(up.IsScalar())
+        {
+            std::string child = up.as<std::string>();
+            if(!child.empty())
+                node["underlying-proxy"] = buildEmbeddedProxy(child, dict, visited);
+            else
+                node.remove("underlying-proxy");
+        }
+        else if(up.IsSequence())
+        {
+            YAML::Node seq;
+            for(auto child : up)
+            {
+                std::string ref = child.as<std::string>();
+                if(ref.empty()) continue;
+                YAML::Node emb = buildEmbeddedProxy(ref, dict, visited);
+                if(emb)
+                    seq.push_back(emb);
+            }
+            if(seq.size())
+                node["underlying-proxy"] = seq;
+            else
+                node.remove("underlying-proxy");
+        }
+    }
+    return node;
 }
 
 bool matchRange(const std::string &range, int target)
@@ -228,7 +272,7 @@ void groupGenerate(const std::string &rule, std::vector<Proxy> &nodelist, string
     }
 }
 
-void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupConfigs &extra_proxy_group, bool clashR, extra_settings &ext)
+void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupConfigs &extra_proxy_group, bool clashR, bool uptree, extra_settings &ext)
 {
     YAML::Node proxies, original_groups;
     std::vector<Proxy> nodelist;
@@ -266,6 +310,8 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
 
         std::string type = getProxyTypeName(x.Type);
         std::string pluginopts = replaceAllDistinct(x.PluginOption, ";", "&");
+        std::string &underlying_proxy = x.UnderlyingProxy;
+
         if(ext.append_proxy_type)
             x.Remark = "[" + type + "] " + x.Remark;
 
@@ -279,7 +325,12 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
         singleproxy["name"] = x.Remark;
         singleproxy["server"] = x.Hostname;
         singleproxy["port"] = x.Port;
-
+        
+        if(!underlying_proxy.empty())
+        {
+            singleproxy["underlying-proxy"] = underlying_proxy;
+        }
+            
         switch(x.Type)
         {
         case ProxyType::Shadowsocks:
@@ -530,33 +581,53 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
             break;
         case ProxyType::Hysteria2:
             singleproxy["type"] = "hysteria2";
-            if (!x.Ports.empty())
+
+            if(!x.Ports.empty())
                 singleproxy["ports"] = x.Ports;
-            if (!x.Up.empty())
+
+            if(x.UpSpeed)
                 singleproxy["up"] = x.UpSpeed;
-            if (!x.Down.empty())
+            if(x.DownSpeed)
                 singleproxy["down"] = x.DownSpeed;
-            if (!x.Password.empty())
+
+            if(!x.Password.empty())
                 singleproxy["password"] = x.Password;
-            if (!x.OBFS.empty())
+
+            if(!x.OBFS.empty())
                 singleproxy["obfs"] = x.OBFS;
-            if (!x.OBFSParam.empty())
+            if(!x.OBFSParam.empty())
                 singleproxy["obfs-password"] = x.OBFSParam;
-            if (!x.SNI.empty())
+
+            if(!x.SNI.empty())
                 singleproxy["sni"] = x.SNI;
-            if (!scv.is_undef())
+            if(!scv.is_undef())
                 singleproxy["skip-cert-verify"] = scv.get();
-            if (!x.Alpn.empty())
+            if(!x.Fingerprint.empty())
+                singleproxy["tls-pubkey-sha256"] = x.Fingerprint;
+
+            if(!x.Alpn.empty())
                 singleproxy["alpn"] = x.Alpn;
-            if (!x.Ca.empty())
+
+            if(!x.Ca.empty())
                 singleproxy["ca"] = x.Ca;
-            if (!x.CaStr.empty())
+            if(!x.CaStr.empty())
                 singleproxy["ca-str"] = x.CaStr;
-            if (x.CWND)
+
+            if(x.CWND)
                 singleproxy["cwnd"] = x.CWND;
-            if (x.HopInterval)
+            if(x.HopInterval)
                 singleproxy["hop-interval"] = x.HopInterval;
+
             break;
+
+        case ProxyType::Direct:
+            singleproxy["type"] = "direct";
+            if(!x.Interface.empty())
+                singleproxy["interface-name"] = x.Interface;
+            singleproxy.remove("server");
+            singleproxy.remove("port");
+            break;
+            
         default:
             continue;
         }
@@ -571,9 +642,68 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
             singleproxy.SetStyle(YAML::EmitterStyle::Block);
         else
             singleproxy.SetStyle(YAML::EmitterStyle::Flow);
+
+        forEachExtra(x, "clash_", [&](const std::string &k, const std::string &v){
+            singleproxy[k] = v;
+        });
+
         proxies.push_back(singleproxy);
         remarks_list.emplace_back(x.Remark);
         nodelist.emplace_back(x);
+    }
+
+    if (uptree)
+    {
+        std::unordered_map<std::string, YAML::Node> proxyDict;
+        for (const auto &p : proxies)
+            proxyDict.emplace(p["name"].as<std::string>(), p);
+
+        std::unordered_set<std::string> referenced;
+
+        for (std::size_t i = 0; i < proxies.size(); ++i)
+        {
+            YAML::Node node = proxies[i];
+            if (!node["underlying-proxy"])
+                continue;
+
+            auto collect = [&](const std::string &ref) {
+                if (ref.empty()) return YAML::Node();
+                std::unordered_set<std::string> visited;
+                YAML::Node emb = buildEmbeddedProxy(ref, proxyDict, visited);
+                referenced.insert(visited.begin(), visited.end());
+                return emb;
+            };
+
+            YAML::Node up = node["underlying-proxy"];
+            if (up.IsScalar())
+            {
+                node["underlying-proxy"] = collect(up.as<std::string>());
+                if (!node["underlying-proxy"])
+                    node.remove("underlying-proxy");
+            }
+            else if (up.IsSequence())
+            {
+                YAML::Node seq;
+                for (auto child : up)
+                {
+                    YAML::Node emb = collect(child.as<std::string>());
+                    if (emb) seq.push_back(emb);
+                }
+                if (seq.size())
+                    node["underlying-proxy"] = seq;
+                else
+                    node.remove("underlying-proxy");
+            }
+
+            proxies[i] = node;
+        }
+
+        YAML::Node filtered;
+        for (const YAML::Node &p : proxies)
+            if (!referenced.count(p["name"].as<std::string>()))
+                filtered.push_back(p);
+
+        proxies = filtered;
     }
 
     if(proxy_compact)
@@ -671,7 +801,7 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
         yamlnode["Proxy Group"] = original_groups;
 }
 
-std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, bool clashR, extra_settings &ext)
+std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, bool clashR, bool uptree, extra_settings &ext)
 {
     YAML::Node yamlnode;
 
@@ -685,7 +815,7 @@ std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf
         return "";
     }
 
-    proxyToClash(nodes, yamlnode, extra_proxy_group, clashR, ext);
+    proxyToClash(nodes, yamlnode, extra_proxy_group, clashR, uptree, ext);
 
     if(ext.nodelist)
         return YAML::Dump(yamlnode);
@@ -722,25 +852,67 @@ std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf
 }
 
 // peer = (public-key = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=, allowed-ips = "0.0.0.0/0, ::/0", endpoint = engage.cloudflareclient.com:2408, client-id = 139/184/125),(public-key = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=, endpoint = engage.cloudflareclient.com:2408)
+
 std::string generatePeer(Proxy &node, bool client_id_as_reserved = false)
 {
     std::string result;
-    result += "public-key = " + node.PublicKey;
-    result += ", endpoint = " + node.Hostname + ":" + std::to_string(node.Port);
+    result += "public-key=\"" + node.PublicKey + "\"";
+    result += ", endpoint=" + node.Hostname + ":" + std::to_string(node.Port);
     if(!node.PreSharedKey.empty())
-        result += ", preshared-key = " + node.PreSharedKey;
+        result += ", preshared-key=\"" + node.PreSharedKey + "\"";
     if(!node.AllowedIPs.empty())
-        result += ", allowed-ips = \"" + node.AllowedIPs + "\"";
+        result += ", allowed-ips=\"" + node.AllowedIPs + "\"";
     if(node.KeepAlive > 0)
-        result += ", keepalive = " + std::to_string(node.KeepAlive);
+        result += ", keepalive=" + std::to_string(node.KeepAlive);
     if(!node.ClientId.empty())
     {
         if(client_id_as_reserved)
-            result += ", reserved = [" + node.ClientId + "]";
+            result += ", reserved=[" + node.ClientId + "]";
         else
-            result += ", client-id = " + node.ClientId;
+            result += ", client-id=\"" + node.ClientId + "\"";
     }
     return result;
+}
+
+static void surgeApplyRulesetFlags(INIReader &ini)
+{
+    string_multimap items;
+    ini.set_current_section("Rule");
+    ini.get_items(items);
+    if(items.empty())
+        return;
+
+    ini.erase_section();
+
+    auto process = [&](std::string line)
+    {
+        if(startsWith(line, "RULE-SET,") || startsWith(line, "DOMAIN-SET,"))
+        {
+            ini.set("{NONAME}", line);
+            return;
+        }
+
+        size_t first = line.find(',');
+        if(first == std::string::npos)
+        {
+            ini.set("{NONAME}", line);
+            return;
+        }
+        std::string type = line.substr(0, first);
+        size_t second = line.find(',', first + 1);
+        std::string pattern = second == std::string::npos ? line.substr(first + 1) : line.substr(first + 1, second - first - 1);
+
+        if(type == "DOMAIN" && (pattern.find('*') != std::string::npos || pattern.find('?') != std::string::npos))
+        {
+            type = "DOMAIN-WILDCARD";
+            line.replace(0, first, type);
+        }
+
+        ini.set("{NONAME}", line);
+    };
+
+    for(const auto &kv : items)
+        process(kv.second);
 }
 
 std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, int surge_ver, extra_settings &ext)
@@ -767,6 +939,14 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
         return "";
     }
 
+    if(!ext.general.empty())
+        for(auto &p : ext.general)
+        {
+            while(ini.item_exist("General", p.first))
+                ini.erase_first("General", p.first);
+            ini.set("General", p.first, p.second);
+        }
+
     ini.set_current_section("Proxy");
     ini.erase_section();
     ini.set("{NONAME}", "DIRECT = direct");
@@ -783,10 +963,10 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
 
         std::string &hostname = x.Hostname, &username = x.Username, &password = x.Password, &method = x.EncryptMethod, &id = x.UserId, &transproto = x.TransferProtocol, &host = x.Host, &edge = x.Edge, &path = x.Path, &protocol = x.Protocol, &protoparam = x.ProtocolParam, &obfs = x.OBFS, &obfsparam = x.OBFSParam, &plugin = x.Plugin, &pluginopts = x.PluginOption, &underlying_proxy = x.UnderlyingProxy;
         std::string port = std::to_string(x.Port);
-        bool &tlssecure = x.TLSSecure;
+        bool &tlssecure = x.TLSSecure, udp = x.UDP.get();
 
-        tribool udp = ext.udp, tfo = ext.tfo, scv = ext.skip_cert_verify, tls13 = ext.tls13;
-        udp.define(x.UDP);
+        tribool tfo = ext.tfo, scv = ext.skip_cert_verify, tls13 = ext.tls13;
+        ext.udp.define(x.UDP);
         tfo.define(x.TCPFastOpen);
         scv.define(x.AllowInsecure);
         tls13.define(x.TLS13);
@@ -944,28 +1124,68 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
         case ProxyType::Hysteria2:
             if(surge_ver < 4)
                 continue;
-            proxy = "hysteria, " + hostname + ", " + port + ", password=" + password;
+            proxy = "Hysteria2, " + hostname + ", " + port;
+
+            if(!x.Password.empty())
+                proxy += ", password=" + x.Password;
+            if(!x.Ports.empty() && x.Ports != port)
+                proxy += ", port-hopping=" + x.Ports;
+
+            if(x.UpSpeed)
+                proxy += ", upload-bandwidth=" + std::to_string(x.UpSpeed);
             if(x.DownSpeed)
-                proxy += ", download-bandwidth=" + x.DownSpeed;
-            
-            if(!scv.is_undef())
-                proxy += ",skip-cert-verify=" + std::string(scv.get() ? "true" : "false");
-            if(!x.Fingerprint.empty())
-                proxy += ",server-cert-fingerprint-sha256=" + x.Fingerprint;
+                proxy += ", download-bandwidth=" + std::to_string(x.DownSpeed);
+
+            if(!x.OBFS.empty())
+                proxy += ", obfs=" + x.OBFS;
+            if(!x.OBFSParam.empty())
+                proxy += ", salamander-password=" + x.OBFSParam;
+
+            if(x.CWND)
+                proxy += ", cwnd=" + std::to_string(x.CWND);
+            if(x.HopInterval)
+                proxy += ", hop-interval=" + std::to_string(x.HopInterval);
+            if(!x.Alpn.empty())
+                proxy += ", alpn=" + x.Alpn[0];
+
             if(!x.SNI.empty())
-                proxy += ",sni=" + x.SNI;
+                proxy += ", sni=" + x.SNI;
+            if(!x.Fingerprint.empty())
+                proxy += ", tls-pubkey-sha256=" + x.Fingerprint;
+
+            if(!x.Ca.empty())
+                proxy += ", ca=" + x.Ca;
+            if(!x.CaStr.empty())
+                proxy += ", ca-str=" + x.CaStr;
+
+            if(!scv.is_undef())
+                proxy += ", skip-cert-verify=" + scv.get_str();
+            if(!tfo.is_undef())
+                proxy += ", fast-open=" + tfo.get_str();
+            if(udp)
+                proxy += ", udp=true";
+            break;
+        case ProxyType::Direct:
+            proxy = "direct";
+            if(!x.Interface.empty())
+                proxy += ", interface=" + x.Interface;
             break;
         default:
             continue;
         }
 
-        if(!tfo.is_undef())
-            proxy += ", tfo=" + tfo.get_str();
-        if(!udp.is_undef())
-            proxy += ", udp-relay=" + udp.get_str();
 
-        if (underlying_proxy != "")
+        if(!ext.tfo.is_undef())
+            proxy += ", tfo=" + ext.tfo.get_str();
+        if(!ext.udp.is_undef())
+            proxy += ", udp-relay=" + ext.udp.get_str();
+
+        if (!underlying_proxy.empty())
             proxy += ", underlying-proxy=" + underlying_proxy;
+
+        forEachExtra(x, "surge_", [&](const std::string &k, const std::string &v){
+            proxy += ", " + k + "=" + v;
+        });
 
         if (ext.nodelist)
             output_nodelist += x.Remark + " = " + proxy + "\n";
@@ -1059,8 +1279,9 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
     }
 
     if(ext.enable_rule_generator)
-        rulesetToSurge(ini, ruleset_content_array, surge_ver, ext.overwrite_original_rules, ext.managed_config_prefix);
+        rulesetToSurge(ini, ruleset_content_array, surge_ver, ext.overwrite_original_rules, ext.managed_config_prefix, ext.embed_remote_rules);
 
+    surgeApplyRulesetFlags(ini);
     return ini.to_string();
 }
 
@@ -1136,6 +1357,24 @@ std::string proxyToSingle(std::vector<Proxy> &nodes, int types, extra_settings &
         default:
             continue;
         }
+
+        auto appendQuery = [&](const std::string &k, const std::string &v)
+        {
+            char sep = (proxyStr.find('?') == std::string::npos) ? '?' : '&';
+            proxyStr += sep + k + "=" + urlEncode(v);
+        };
+
+        forEachExtra(x, "single_", appendQuery);
+
+        switch (x.Type)
+        {
+            case ProxyType::Shadowsocks:   forEachExtra(x, "ss_",     appendQuery); break;
+            case ProxyType::ShadowsocksR:  forEachExtra(x, "ssr_",    appendQuery); break;
+            case ProxyType::VMess:         forEachExtra(x, "vmess_",  appendQuery); break;
+            case ProxyType::Trojan:        forEachExtra(x, "trojan_", appendQuery); break;
+            default: break;
+        }
+
         allLinks += proxyStr + "\n";
     }
 
@@ -1193,6 +1432,12 @@ std::string proxyToSSSub(std::string base_conf, std::vector<Proxy> &nodes, extra
         | AddMemberOrReplace("password", rapidjson::Value(password.c_str(), password.size()), alloc)
         | AddMemberOrReplace("plugin", rapidjson::Value(plugin.c_str(), plugin.size()), alloc)
         | AddMemberOrReplace("plugin_opts", rapidjson::Value(pluginopts.c_str(), pluginopts.size()), alloc);
+
+        forEachExtra(x, "sssub_", [&](const std::string &k, const std::string &v){
+            proxy.AddMember(rapidjson::Value(k.c_str(), alloc),
+                            rapidjson::Value(v.c_str(), alloc), alloc);
+        });
+
         proxies.PushBack(proxy, alloc);
     }
     return proxies | SerializeObject();
@@ -1349,6 +1594,8 @@ void proxyToQuan(std::vector<Proxy> &nodes, INIReader &ini, std::vector<RulesetC
             continue;
         }
 
+        forEachExtra(x, "quan_",   [&](const std::string &k, const std::string &v){  proxyStr += ", " + k + "=" + v; });
+
         ini.set("{NONAME}", proxyStr);
         remarks_list.emplace_back(x.Remark);
         nodelist.emplace_back(x);
@@ -1421,7 +1668,7 @@ void proxyToQuan(std::vector<Proxy> &nodes, INIReader &ini, std::vector<RulesetC
     }
 
     if(ext.enable_rule_generator)
-        rulesetToSurge(ini, ruleset_content_array, -2, ext.overwrite_original_rules, "");
+        rulesetToSurge(ini, ruleset_content_array, -2, ext.overwrite_original_rules, "", ext.embed_remote_rules);
 }
 
 std::string proxyToQuanX(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext)
@@ -1440,6 +1687,14 @@ std::string proxyToQuanX(std::vector<Proxy> &nodes, const std::string &base_conf
         writeLog(0, "QuantumultX base loader failed with error: " + ini.get_last_error(), LOG_LEVEL_ERROR);
         return "";
     }
+
+    if(!ext.general.empty())
+        for(auto &p : ext.general)
+        {
+            while(ini.item_exist("general", p.first))
+                ini.erase_first("general", p.first);
+            ini.set("general", p.first, p.second);
+        }
 
     proxyToQuanX(nodes, ini, ruleset_content_array, extra_proxy_group, ext);
 
@@ -1605,6 +1860,8 @@ void proxyToQuanX(std::vector<Proxy> &nodes, INIReader &ini, std::vector<Ruleset
             proxyStr += ", tls-verification=" + scv.reverse().get_str();
         proxyStr += ", tag=" + x.Remark;
 
+        forEachExtra(x, "quanx_",  [&](const std::string &k, const std::string &v){  proxyStr += ", " + k + "=" + v; });
+
         ini.set("{NONAME}", proxyStr);
         remarks_list.emplace_back(x.Remark);
         nodelist.emplace_back(x);
@@ -1690,7 +1947,7 @@ void proxyToQuanX(std::vector<Proxy> &nodes, INIReader &ini, std::vector<Ruleset
     }
 
     if(ext.enable_rule_generator)
-        rulesetToSurge(ini, ruleset_content_array, -1, ext.overwrite_original_rules, ext.managed_config_prefix);
+        rulesetToSurge(ini, ruleset_content_array, -1, ext.overwrite_original_rules, ext.managed_config_prefix, ext.embed_remote_rules);
 }
 
 std::string proxyToSSD(std::vector<Proxy> &nodes, std::string &group, std::string &userinfo, extra_settings &ext)
@@ -1785,6 +2042,12 @@ std::string proxyToSSD(std::vector<Proxy> &nodes, std::string &group, std::strin
         default:
             continue;
         }
+
+        forEachExtra(x, "ssd_", [&](const std::string &k, const std::string &v){
+            writer.Key(k.c_str());
+            writer.String(v.c_str());
+        });
+
         index++;
     }
     writer.EndArray();
@@ -1886,7 +2149,9 @@ void proxyToMellow(std::vector<Proxy> &nodes, INIReader &ini, std::vector<Rulese
         default:
             continue;
         }
-
+        
+        forEachExtra(x, "mellow_", [&](const std::string &k, const std::string &v){  proxy   += ", " + k + "=" + v; });
+        
         ini.set("{NONAME}", proxy);
         remarks_list.emplace_back(x.Remark);
         nodelist.emplace_back(x);
@@ -1944,7 +2209,7 @@ void proxyToMellow(std::vector<Proxy> &nodes, INIReader &ini, std::vector<Rulese
     }
 
     if(ext.enable_rule_generator)
-        rulesetToSurge(ini, ruleset_content_array, 0, ext.overwrite_original_rules, "");
+        rulesetToSurge(ini, ruleset_content_array, 0, ext.overwrite_original_rules, "", ext.embed_remote_rules);
 }
 
 std::string proxyToLoon(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext)
@@ -1975,12 +2240,17 @@ std::string proxyToLoon(std::vector<Proxy> &nodes, const std::string &base_conf,
         }
         processRemark(x.Remark, remarks_list);
 
-        std::string &hostname = x.Hostname, &username = x.Username, &password = x.Password, &method = x.EncryptMethod, &plugin = x.Plugin, &pluginopts = x.PluginOption, &id = x.UserId, &transproto = x.TransferProtocol, &host = x.Host, &path = x.Path, &protocol = x.Protocol, &protoparam = x.ProtocolParam, &obfs = x.OBFS, &obfsparam = x.OBFSParam;
+        std::string &hostname = x.Hostname, &username = x.Username, &password = x.Password,
+            &method = x.EncryptMethod, &plugin = x.Plugin, &pluginopts = x.PluginOption,
+            &id = x.UserId, &transproto = x.TransferProtocol, &host = x.Host, &path = x.Path,
+            &protocol = x.Protocol, &protoparam = x.ProtocolParam, &obfs = x.OBFS,
+            &obfsparam = x.OBFSParam, &underlying_proxy = x.UnderlyingProxy;
         std::string port = std::to_string(x.Port), aid = std::to_string(x.AlterId);
-        bool &tlssecure = x.TLSSecure;
+        bool &tlssecure = x.TLSSecure, udp = x.UDP.get();
 
         tribool scv = ext.skip_cert_verify;
         scv.define(x.AllowInsecure);
+        ext.udp.define(x.UDP);
 
         std::string proxy;
 
@@ -2054,7 +2324,7 @@ std::string proxyToLoon(std::vector<Proxy> &nodes, const std::string &base_conf,
             proxy = "wireguard, interface-ip=" + x.SelfIP;
             if(!x.SelfIPv6.empty())
                 proxy += ", interface-ipv6=" + x.SelfIPv6;
-            proxy += ", private-key=" + x.PrivateKey;
+            proxy += ", private-key=\"" + x.PrivateKey + "\"";
             for(const auto &y : x.DnsServers)
             {
                 if(isIPv4(y))
@@ -2068,15 +2338,56 @@ std::string proxyToLoon(std::vector<Proxy> &nodes, const std::string &base_conf,
                 proxy += ", keepalive=" + std::to_string(x.KeepAlive);
             proxy += ", peers=[{" + generatePeer(x, true) + "}]";
             break;
+        case ProxyType::Hysteria2:
+            proxy = "Hysteria2," + hostname + "," + port;
+            if (!password.empty())
+                proxy += ", \"" + password + "\"";
+            if (!x.Ports.empty() && x.Ports != port)
+                proxy += ", port-hopping=" + x.Ports;
+
+            if (x.UpSpeed)
+                proxy += ", upload-bandwidth=" + std::to_string(x.UpSpeed);
+            if (x.DownSpeed)
+                proxy += ", download-bandwidth=" + std::to_string(x.DownSpeed);
+
+            if (!obfs.empty())
+                proxy += ", obfs=" + obfs;
+            if (!obfsparam.empty())
+                proxy += ", salamander-password=" + obfsparam;
+
+            if (x.CWND)
+                proxy += ", cwnd=" + std::to_string(x.CWND);
+            if (x.HopInterval)
+                proxy += ", hop-interval=" + std::to_string(x.HopInterval);
+
+            if (!x.Alpn.empty())
+                proxy += ", alpn=" + x.Alpn[0];
+
+            if (!x.SNI.empty())
+                proxy += ", sni=" + x.SNI;
+            if (!x.Fingerprint.empty())
+                proxy += ", tls-pubkey-sha256=" + x.Fingerprint;
+
+            if (!x.Ca.empty())
+                proxy += ", ca=" + x.Ca;
+            if (!x.CaStr.empty())
+                proxy += ", ca-str=" + x.CaStr;
+
+            if (!scv.is_undef())
+                proxy += ", skip-cert-verify=" + scv.get_str();
+            break;
         default:
             continue;
         }
 
+        if (!underlying_proxy.empty())
+            proxy += ", underlying-proxy=" + underlying_proxy;
         if(ext.tfo)
             proxy += ",fast-open=true";
-        if(ext.udp)
+        if((ext.udp.is_undef() && udp) || ext.udp)
             proxy += ",udp=true";
 
+        forEachExtra(x, "loon_",   [&](const std::string &k, const std::string &v){  proxy   += ", " + k + "=" + v; });
 
         if(ext.nodelist)
             output_nodelist += x.Remark + " = " + proxy + "\n";
@@ -2168,7 +2479,7 @@ std::string proxyToLoon(std::vector<Proxy> &nodes, const std::string &base_conf,
     }
 
     if(ext.enable_rule_generator)
-        rulesetToSurge(ini, ruleset_content_array, -4, ext.overwrite_original_rules, ext.managed_config_prefix);
+        rulesetToSurge(ini, ruleset_content_array, -4, ext.overwrite_original_rules, ext.managed_config_prefix, ext.embed_remote_rules);
 
     return ini.to_string();
 }
@@ -2413,11 +2724,11 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
             case ProxyType::Hysteria2:
             {
                 addSingBoxCommonMembers(proxy, x, "hysteria2", allocator);
-                if (!x.Ports.empty())
+                if(!x.Ports.empty())
                     proxy.AddMember("server_ports", stringArrayToJsonArray(x.Ports, ",", allocator), allocator);
-                if (!x.Up.empty())
+                if(x.UpSpeed)
                     proxy.AddMember("up_mbps", x.UpSpeed, allocator);
-                if (!x.Down.empty())
+                if(x.DownSpeed)
                     proxy.AddMember("down_mbps", x.DownSpeed, allocator);
                 if (!x.OBFS.empty())
                 {
@@ -2490,6 +2801,12 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
         {
             proxy.AddMember("tcp_fast_open", buildBooleanValue(tfo), allocator);
         }
+        
+        forEachExtra(x, "singbox_", [&](const std::string &k, const std::string &v){
+            proxy.AddMember(rapidjson::Value(k.c_str(), allocator),
+                            rapidjson::Value(v.c_str(), allocator), allocator);
+        });
+
         nodelist.push_back(x);
         remarks_list.emplace_back(x.Remark);
         outbounds.PushBack(proxy, allocator);

--- a/src/generator/config/subexport.h
+++ b/src/generator/config/subexport.h
@@ -19,6 +19,7 @@ struct extra_settings
 {
     bool enable_rule_generator = true;
     bool overwrite_original_rules = true;
+    bool embed_remote_rules = true;
     RegexMatchConfigs rename_array;
     RegexMatchConfigs emoji_array;
     bool add_emoji = false;
@@ -31,7 +32,9 @@ struct extra_settings
     bool clash_script = false;
     std::string surge_ssr_path;
     std::string managed_config_prefix;
+    std::string managed_config_url;
     std::string quanx_dev_id;
+    string_map general;
     tribool udp = tribool();
     tribool tfo = tribool();
     tribool skip_cert_verify = tribool();
@@ -58,8 +61,8 @@ struct extra_settings
 #endif // NO_JS_RUNTIME
 };
 
-std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, bool clashR, extra_settings &ext);
-void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupConfigs &extra_proxy_group, bool clashR, extra_settings &ext);
+std::string proxyToClash(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, bool clashR, bool uptree, extra_settings &ext);
+void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGroupConfigs &extra_proxy_group, bool clashR, bool uptree, extra_settings &ext);
 std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, int surge_ver, extra_settings &ext);
 std::string proxyToMellow(std::vector<Proxy> &nodes, const std::string &base_conf, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext);
 void proxyToMellow(std::vector<Proxy> &nodes, INIReader &ini, std::vector<RulesetContent> &ruleset_content_array, const ProxyGroupConfigs &extra_proxy_group, extra_settings &ext);

--- a/src/handler/settings.h
+++ b/src/handler/settings.h
@@ -22,10 +22,10 @@ struct Settings
     RulesetConfigs customRulesets;
     RegexMatchConfigs streamNodeRules, timeNodeRules;
     std::vector<RulesetContent> rulesetsContent;
-    std::string listenAddress = "127.0.0.1", defaultUrls, insertUrls, managedConfigPrefix;
+    std::string listenAddress = "127.0.0.1", defaultUrls, insertUrls, managedConfigPrefix, managedConfigUrl;
     int listenPort = 25500, maxPendingConns = 10, maxConcurThreads = 4;
     bool prependInsert = true, skipFailedLinks = false;
-    bool APIMode = true, writeManagedConfig = false, enableRuleGen = true, updateRulesetOnRequest = false, overwriteOriginalRules = true;
+    bool APIMode = true, writeManagedConfig = false, enableRuleGen = true, updateRulesetOnRequest = false, overwriteOriginalRules = true, embedRemoteRules = false;
     bool printDbgInfo = false, CFWChildProcess = false, appendUserinfo = true, asyncFetchRuleset = false, surgeResolveHostname = true;
     std::string accessToken, basePath = "base";
     std::string custom_group;
@@ -76,6 +76,7 @@ struct ExternalConfig
 {
     ProxyGroupConfigs custom_proxy_group;
     RulesetConfigs surge_ruleset;
+    std::string managed_config_url;
     std::string clash_rule_base;
     std::string surge_rule_base;
     std::string surfboard_rule_base;
@@ -89,8 +90,10 @@ struct ExternalConfig
     RegexMatchConfigs emoji;
     string_array include;
     string_array exclude;
+    string_map general;
     template_args *tpl_args = nullptr;
     bool overwrite_original_rules = false;
+    bool embed_remote_rules = false;
     bool enable_rule_generator = true;
     tribool add_emoji;
     tribool remove_old_emoji;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,8 +167,10 @@ int main(int argc, char *argv[])
     if(!global.updateRulesetOnRequest)
         refreshRulesets(global.customRulesets, global.rulesetsContent);
 
-    std::string env_api_mode = getEnv("API_MODE"), env_managed_prefix = getEnv("MANAGED_PREFIX"), env_token = getEnv("API_TOKEN");
+    std::string env_api_mode = getEnv("API_MODE"), env_managed_prefix = getEnv("MANAGED_PREFIX"), env_managed_url = getEnv("MANAGED_URL"), env_token = getEnv("API_TOKEN");
     global.APIMode = tribool().parse(toLower(env_api_mode)).get(global.APIMode);
+    if(!env_managed_url.empty())
+        global.managedConfigUrl = env_managed_url;
     if(!env_managed_prefix.empty())
         global.managedConfigPrefix = env_managed_prefix;
     if(!env_token.empty())

--- a/src/parser/config/proxy.h
+++ b/src/parser/config/proxy.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "utils/tribool.h"
 
@@ -22,7 +23,8 @@ enum class ProxyType
     SOCKS5,
     WireGuard,
     Hysteria,
-    Hysteria2
+    Hysteria2,
+    Direct
 };
 
 inline String getProxyTypeName(ProxyType type)
@@ -51,6 +53,8 @@ inline String getProxyTypeName(ProxyType type)
         return "Hysteria";
     case ProxyType::Hysteria2:
         return "Hysteria2";
+    case ProxyType::Direct:
+        return "Direct";
     default:
         return "Unknown";
     }
@@ -97,7 +101,8 @@ struct Proxy
 
     uint16_t SnellVersion = 0;
     String ServerName;
-
+    String Interface;
+    
     String SelfIP;
     String SelfIPv6;
     String PublicKey;
@@ -125,9 +130,27 @@ struct Proxy
     tribool DisableMtuDiscovery;
     uint32_t HopInterval;
     StringArray Alpn;
+    std::unordered_map<std::string, std::string> Extra;
 
     uint32_t CWND = 0;
 };
+
+inline void addExtraField(Proxy &proxy, const std::string &key, const std::string &val)
+{
+    if(key.empty()) return;
+    proxy.Extra.emplace(key, val);
+}
+
+template<typename Fn>
+inline void forEachExtra(const Proxy &proxy, const std::string &prefix, Fn cb)
+{
+    const auto plen = prefix.size();
+    for(const auto &kv : proxy.Extra)
+    {
+        if(kv.first.rfind(prefix, 0) == 0 && kv.first.size() > plen)
+            cb(kv.first.substr(plen), kv.second);
+    }
+}
 
 #define SS_DEFAULT_GROUP "SSProvider"
 #define SSR_DEFAULT_GROUP "SSRProvider"


### PR DESCRIPTION
Add embed_remote_rules flag, Stash export, Hysteria2 fix & extended extra-param handling

### What's new
- **Global `embed_remote_rules` flag** (default `false`)  
  - When `true`, remote rule-set links are fetched and their content embedded under **Rule**, leaving **Remote Rule** empty – behaviour now mirrors Clash.
- **Native Stash output** (`target=stash`) for seamless iOS client usage.
- **Hysteria 2**: corrected URI parse / emit logic.
- **Extra-param parser upgrades** for single / SS family protocols (supports `sni`, `flow`, `skip-cert-verify`, etc.).
- **Custom-fields** kept intact through conversion.

### Why
Embedding rules removes startup network calls and enables fully offline, self-contained configs.
Bug-fixes and extra-param support unlock advanced options without manual edits.

### Notes
Behaviour is unchanged when `embed_remote_rules` remains at its default (`false`).