### PR TITLE
1. Modify the User-Agent in the request from Surge. 2. Handling IPv6

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -795,6 +795,13 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
         string_array args, headers;
 
         std::stringstream ss;
+        // Preprocess IPv6
+        if (!hostname.empty() && hostname.front() == '[') {
+            hostname.erase(0, 1);
+        }
+        if (!hostname.empty() && hostname.back() == ']') {
+            hostname.pop_back();
+        }
 
         switch (x.Type)
         {

--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -609,6 +609,28 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
     parse_set.time_rules = &time_temp;
     parse_set.sub_info = &subInfo;
     parse_set.authorized = authorized;
+    // modify UA header for Surge
+    auto it = request.headers.find("User-Agent");
+
+    if (it != request.headers.end()) {
+
+        std::string& user_agent_value = it->second;
+
+        std::string target_string = "surge";
+
+        auto search_it = std::search(
+                user_agent_value.begin(), user_agent_value.end(),
+                target_string.begin(), target_string.end(),
+                [](unsigned char ch1, unsigned char ch2) {
+                    return std::tolower(ch1) == std::tolower(ch2);
+                }
+        );
+
+        if (search_it != user_agent_value.end()) {
+            user_agent_value = "Subconverter_custom_header";
+        }
+    }
+
     parse_set.request_header = &request.headers;
     parse_set.js_runtime = ext.js_runtime;
     parse_set.js_context = ext.js_context;


### PR DESCRIPTION
1. Modify the User-Agent in the request from Surge. When some universal subscription links identify User-Agent as Surge, some nodes will be dropped. (e.g.: encrypt-method=2022-blake3-aes-128-gcm)
2. If the node's hostname (IPv6) begins and ends with [], remove them.