### PR TITLE
Support hysteria2 port ranges in URI import

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -112,6 +112,18 @@ bool matchRange(const std::string &range, int target)
     return match;
 }
 
+static bool shouldOmitClashPortForHysteria2(const Proxy &node)
+{
+    if (node.Type != ProxyType::Hysteria2 || node.Ports.empty())
+        return false;
+
+    string_array port_list = split(node.Ports, ",");
+    if (port_list.size() > 1)
+        return true;
+
+    return trim(port_list[0]).find('-') != std::string::npos;
+}
+
 bool applyMatcher(const std::string &rule, std::string &real_rule, const Proxy &node)
 {
     std::string target, ret_real_rule;
@@ -279,7 +291,8 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
 
         singleproxy["name"] = x.Remark;
         singleproxy["server"] = x.Hostname;
-        singleproxy["port"] = x.Port;
+        if (!shouldOmitClashPortForHysteria2(x))
+            singleproxy["port"] = x.Port;
 
         switch(x.Type)
         {

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -39,6 +39,31 @@ void commonConstruct(Proxy &node, ProxyType type, const std::string &group, cons
     node.TLS13 = tls13;
 }
 
+static std::string getPrimaryPortFromPortSpec(const std::string &port_spec)
+{
+    string_array port_list = split(port_spec, ",");
+    for (const auto &raw_port : port_list)
+    {
+        std::string port_entry = trim(raw_port);
+        if (port_entry.empty())
+            continue;
+
+        auto range_pos = port_entry.find('-');
+        if (range_pos != std::string::npos)
+        {
+            std::string range_begin = trim(port_entry.substr(0, range_pos));
+            if (regMatch(range_begin, R"(\d+)"))
+                return range_begin;
+            continue;
+        }
+
+        if (regMatch(port_entry, R"(\d+)"))
+            return port_entry;
+    }
+
+    return "";
+}
+
 void vmessConstruct(Proxy &node, const std::string &group, const std::string &remarks, const std::string &add, const std::string &port, const std::string &type, const std::string &id, const std::string &aid, const std::string &net, const std::string &cipher, const std::string &path, const std::string &host, const std::string &edge, const std::string &tls, const std::string &sni, tribool udp, tribool tfo, tribool scv, tribool tls13, const std::string& underlying_proxy)
 {
     commonConstruct(node, ProxyType::VMess, group, remarks, add, port, udp, tfo, scv, tls13, underlying_proxy);
@@ -1114,7 +1139,10 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
         singleproxy["name"] >>= ps;
         singleproxy["server"] >>= server;
         singleproxy["port"] >>= port;
+        singleproxy["ports"] >>= ports;
         singleproxy["underlying-proxy"] >>= underlying_proxy;
+        if((port.empty() || port == "0") && (proxytype == "hysteria" || proxytype == "hysteria2"))
+            port = getPrimaryPortFromPortSpec(ports);
         if(port.empty() || port == "0")
             continue;
         udp = safe_as<std::string>(singleproxy["udp"]);
@@ -1366,7 +1394,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             singleproxy["cwnd"] >>= cwnd;
             singleproxy["hop-interval"] >>= hop_interval;
 
-            hysteria2Construct(node, group, ps, server, port, ports, up, down, password, obfs, obfs_password, sni, fingerprint, ca, ca_str, cwnd, alpn, hop_interval, tfo, scv, underlying_proxy);
+            hysteria2Construct(node, group, ps, server, port, ports, up, down, password, obfs, obfs_password, sni, fingerprint, alpn, ca, ca_str, cwnd, hop_interval, tfo, scv, underlying_proxy);
             break;
 
         default:
@@ -1506,7 +1534,7 @@ void explodeKitsunebi(std::string kit, Proxy &node)
 
 
 void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
-    std::string add, port, password, host, insecure, up, down, alpn, obfs, obfs_password, remarks, sni, fingerprint;
+    std::string add, port, ports, password, host, insecure, up, down, alpn, obfs, obfs_password, remarks, sni, fingerprint;
     std::string addition;
     tribool scv;
     hysteria2 = hysteria2.substr(12);
@@ -1525,7 +1553,7 @@ void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
     }
 
     if (strFind(hysteria2, "@")) {
-        if (regGetMatch(hysteria2, R"(^(.*?)@(.*)[:](\d+)$)", 4, 0, &password, &add, &port))
+        if (regGetMatch(hysteria2, R"(^(.*?)@(.*)[:](\d[\d,-]*)$)", 4, 0, &password, &add, &ports))
             return;
     } else {
         password = getUrlArg(addition, "password");
@@ -1535,9 +1563,17 @@ void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
         if (!strFind(hysteria2, ":"))
             return;
 
-        if (regGetMatch(hysteria2, R"(^(.*)[:](\d+)$)", 3, 0, &add, &port))
+        if (regGetMatch(hysteria2, R"(^(.*)[:](\d[\d,-]*)$)", 3, 0, &add, &ports))
             return;
     }
+
+    if (regMatch(ports, R"(\d+)"))
+        port = ports;
+    else
+        port = getPrimaryPortFromPortSpec(ports);
+
+    if (port.empty())
+        return;
 
     scv = getUrlArg(addition, "insecure");
     up = getUrlArg(addition, "up");
@@ -1549,9 +1585,9 @@ void explodeStdHysteria2(std::string hysteria2, Proxy &node) {
     sni = getUrlArg(addition, "sni");
     fingerprint = getUrlArg(addition, "pinSHA256");
     if (remarks.empty())
-        remarks = add + ":" + port;
+        remarks = add + ":" + ports;
 
-    hysteria2Construct(node, HYSTERIA2_DEFAULT_GROUP, remarks, add, port, port, up, down, password, obfs, obfs_password, sni, fingerprint, "", "", "", "", "", tribool(), scv, "");
+    hysteria2Construct(node, HYSTERIA2_DEFAULT_GROUP, remarks, add, port, regMatch(ports, R"(\d+)") ? "" : ports, up, down, password, obfs, obfs_password, sni, fingerprint, "", "", "", "", "", tribool(), scv, "");
     return;
 }
 


### PR DESCRIPTION
  ## Summary

  This PR adds support for importing Hysteria 2 standard URIs that use a port range or multi-port spec in the authority section.

  Previously, these links were rejected as invalid because the parser only accepted a single numeric port.

  ## Problem

  The current Hysteria 2 URI parser only matches a numeric-only `port` value. As a result, valid port hopping style inputs such as port ranges or comma-separated port specs cannot be imported from standard URIs.

  There is also an argument ordering issue in the Clash importer path for Hysteria 2, which can cause fields such as `alpn`, `ca`, and `cwnd` to be assigned incorrectly.

  ## Changes

  - Allow Hysteria 2 standard URI parsing to accept port specs containing ranges and multiple ports
  - Preserve the full port spec in `Ports`
  - Derive a primary port internally from the first valid entry only when required by the internal proxy model
  - When exporting to Clash, omit `port` for Hysteria 2 if `ports` contains a range or multiple ports, and emit only `ports`
  - Keep existing single-port behavior unchanged
  - Fix the Hysteria 2 argument order in the Clash import path

   ## Result

  A URI like:

  `hysteria2://password@<server>:<port-range>/?sni=<server>#example-node`

  is now converted to Clash output like:

  ```yaml
  - {name: example-node, server: <server>, type: hysteria2, ports: <port-range>, password: password, sni: <server>}

  A Hysteria 2 URI with a single port still produces:

  `hysteria2://password@<server>:<single-port>/?sni=<server>#example-node`

  - {name: example-node, server: <server>, port: <single-port>, type: hysteria2, password: password, sni: <server>}
